### PR TITLE
fix tag capitalization

### DIFF
--- a/guides/dag-best-practices.md
+++ b/guides/dag-best-practices.md
@@ -4,7 +4,7 @@ description: "How to create effective, clean, and functional DAGs."
 date: 2018-05-21T00:00:00.000Z
 slug: "dag-best-practices"
 heroImagePath: "https://assets.astronomer.io/website/img/guides/bestwritingpractices.png"
-tags: ["Dags", "Best Practices", "Basics", "Templating", "Tasks"]
+tags: ["DAGs", "Best Practices", "Basics", "Templating", "Tasks"]
 ---
 
 Welcome to our guide on writing Airflow DAGs. In this piece, we'll walk through some high-level concepts involved in Airflow DAGs, explain what to stay away from, and cover some useful tricks that will hopefully be helpful to you.


### PR DESCRIPTION
This single outlier is causing a duplicate on the website tag sidebar. We should probably make the tags case-agnostic on the website too.

![image](https://user-images.githubusercontent.com/3267/99300477-a5bfc000-281a-11eb-938a-b66be0e89d7c.png)
