### PR TITLE
Use consistent naming convention across packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,19 +1,19 @@
 {
-  "name": "airflow_guides",
+  "name": "astro-guides",
   "version": "1.0.0",
-  "description": "A series of guides for using Apache Airflow with Astronomer",
+  "description": "Tutorials and best practices for using Apache Airflow",
   "main": "index.js",
   "scripts": {
     "start": "npm start"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/astronomerio/airflow_guides.git"
+    "url": "git+https://github.com/astronomer/airflow-guides.git"
   },
   "author": "",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/astronomerio/airflow_guides/issues"
+    "url": "https://github.com/astronomer/airflow-guides/issues"
   },
-  "homepage": "https://github.com/astronomerio/airflow_guides#readme"
+  "homepage": "https://github.com/astronomer/airflow-guides#readme"
 }


### PR DESCRIPTION
This is repo is a dependency of astronomer/astro-site. As depicted below it is one of three content dependencies, each with different package naming conventions. This will be one of a series of PRs to update to a common naming convention. I'll just be updating the package names, not the repo names.

![image](https://user-images.githubusercontent.com/3267/101791857-04065880-3ad2-11eb-8aa7-b70b334e4b7b.png)

New naming convention:
```json
"dependencies": {
    "astro-guides": "astronomer/airflow-guides",
    "astro-blog": "astronomer/astro-blog",
    "astro-docs": "astronomer/docs",
}
```