### PR TITLE
Replaced references to max_threads in two guides

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -1616,3 +1616,4 @@ mongo_to_redshift.py
  - guides/airflow-databricks.md
 parameterizing
 granularly
+parsing_processes

--- a/.spelling
+++ b/.spelling
@@ -1606,9 +1606,14 @@ mongo_to_redshift.py
 parameterizing
 granularly
 AzureContainerInstancesOperator
+AzureDataExplorerQueryOperator
 ci\_conn\_id
 DockerHub
 memory\_in\_gb
 parsing_processes
 max_threads
 ConnType
+auth_method
+AzureContainerInstanceHook
+Covid-19
+david-astro

--- a/.spelling
+++ b/.spelling
@@ -3,6 +3,16 @@
 # global dictionary is at the start, file overrides afterwards
 # one word per line, to define a file override use ' - filename'
 # where filename is relative to this configuration file
+AzureContainerInstancesOperator
+AzureContainerInstanceHook
+AzureDataExplorerQueryOperator
+DockerHub
+Covid-19
+david-astro
+Covid
+ConnType
+ci
+gb
 graphql
 pinterest
 shopify
@@ -60,7 +70,7 @@ autoscaler
 airflow
 airflowers
 iberman
-boolean
+boolean 
 astronomerio
 dbaas
 datahub
@@ -68,6 +78,7 @@ toolset
 hoc
 grafana
 metabase
+auth_method
 cloudwatch
 mozaik
 whitelisted
@@ -906,7 +917,7 @@ Mika
 Heino
 Solita
 VideoAmp
-How-to's
+How-to's 
 Peyman
 Mohajerian
 Vinayak
@@ -1477,14 +1488,14 @@ Create_DAG
 __`e
 ____
 - guides/facebook-ads-to-redshift.md
-age_gender
+age_gender 
 device_platform
 region_country
 no_breakdown
 account_id
 ad_id
 adset_id
-ad_name
+ad_name 
 adset_name
 campaign_id
 date_start
@@ -1503,7 +1514,7 @@ facebook_ads_to_redshift.py
 v18.09
 - guides/github-to-redshift.md
 issue_comments
-pull_requests
+pull_requests 
 github_to_redshift.py
 - guides/google-analytics-to-redshift.md
 v4
@@ -1605,15 +1616,3 @@ mongo_to_redshift.py
  - guides/airflow-databricks.md
 parameterizing
 granularly
-AzureContainerInstancesOperator
-AzureDataExplorerQueryOperator
-ci\_conn\_id
-DockerHub
-memory\_in\_gb
-parsing_processes
-max_threads
-ConnType
-auth_method
-AzureContainerInstanceHook
-Covid-19
-david-astro

--- a/.spelling
+++ b/.spelling
@@ -3,16 +3,6 @@
 # global dictionary is at the start, file overrides afterwards
 # one word per line, to define a file override use ' - filename'
 # where filename is relative to this configuration file
-AzureContainerInstancesOperator
-AzureContainerInstanceHook
-AzureDataExplorerQueryOperator
-DockerHub
-Covid-19
-david-astro
-Covid
-ConnType
-ci
-gb
 graphql
 pinterest
 shopify
@@ -70,7 +60,7 @@ autoscaler
 airflow
 airflowers
 iberman
-boolean 
+boolean
 astronomerio
 dbaas
 datahub
@@ -78,7 +68,6 @@ toolset
 hoc
 grafana
 metabase
-auth_method
 cloudwatch
 mozaik
 whitelisted
@@ -917,7 +906,7 @@ Mika
 Heino
 Solita
 VideoAmp
-How-to's 
+How-to's
 Peyman
 Mohajerian
 Vinayak
@@ -1488,14 +1477,14 @@ Create_DAG
 __`e
 ____
 - guides/facebook-ads-to-redshift.md
-age_gender 
+age_gender
 device_platform
 region_country
 no_breakdown
 account_id
 ad_id
 adset_id
-ad_name 
+ad_name
 adset_name
 campaign_id
 date_start
@@ -1514,7 +1503,7 @@ facebook_ads_to_redshift.py
 v18.09
 - guides/github-to-redshift.md
 issue_comments
-pull_requests 
+pull_requests
 github_to_redshift.py
 - guides/google-analytics-to-redshift.md
 v4
@@ -1616,3 +1605,10 @@ mongo_to_redshift.py
  - guides/airflow-databricks.md
 parameterizing
 granularly
+AzureContainerInstancesOperator
+ci\_conn\_id
+DockerHub
+memory\_in\_gb
+parsing_processes
+max_threads
+ConnType

--- a/guides/airflow-executors-explained.md
+++ b/guides/airflow-executors-explained.md
@@ -45,7 +45,9 @@ When we're talking about task execution, you'll want to be familiar with these [
 
 - **pool**: Pools are configurable via the Airflow UI and are used to limit the _parallelism_ on any particular set of tasks. You could use it to give some tasks priority over others, or to put a cap on execution for things like hitting a third party API that has rate limits on it, for example.
 
-- **max_threads**: This determines how many linear scheduling _processes_ the scheduler can handle in parallel at any given time. The default value is 2, but adjusting this number gives you some control over CPU usage - the higher the value, the more resources you'll need.
+- **parsing_processes**: This determines how many linear scheduling _processes_ the scheduler can handle in parallel at any given time. The default value is 2, but adjusting this number gives you some control over CPU usage - the higher the value, the more resources you'll need.
+
+  > Note: In Airflow 1.10.13 and prior versions, this setting is called max_threads.
 
   > Note: Rather than trying to find one set of configurations that work for _all_ jobs, we'd recommend grouping jobs by their type as much as you can.
 

--- a/guides/airflow-scaling-workers.md
+++ b/guides/airflow-scaling-workers.md
@@ -1,5 +1,5 @@
 ---
-title: "Scaling out Airflow"
+title: "Scaling Out Airflow"
 description: "How to scale out Airflow workers and the settings needed to maximize parallelism"
 date: 2019-03-13T00:00:00.000Z
 slug: "airflow-scaling-workers"

--- a/guides/airflow-scaling-workers.md
+++ b/guides/airflow-scaling-workers.md
@@ -37,8 +37,8 @@ Here are the settings and their default values.
     <td align="center">16</td>
   </tr>
   <tr>
-    <td>max_threads</td>
-    <td>AIRFLOW__SCHEDULER__MAX_THREADS</td>
+    <td>parsing_processes</td>
+    <td>AIRFLOW__SCHEDULER__PARSING_PROCESSES</td>
     <td align="center">2</td>
   </tr>
 </table>
@@ -62,7 +62,9 @@ If you're using Astronomer, you can configure both worker resources and environm
 
 If you decide to increase these settings, Airflow will be able to scale up and process many tasks in parallel. This could however put a strain on the scheduler. For example, you may notice delays in task execution, tasks remaining a in `queued` state for longer than expected, or gaps in the Gantt chart of the Airflow UI.
 
-The **max_threads = 2** setting can be used to increase the number of threads running on the scheduler. This can prevent the scheduler from getting behind, but may also require more resources. If you increase this, you may need to increase CPU and/or memory on your scheduler. This should be set to n-1 where n is the number of CPUs of your scheduler.
+The **parsing_processes = 2** setting can be used to increase the number of threads running on the scheduler. This can prevent the scheduler from getting behind, but may also require more resources. If you increase this, you may need to increase CPU and/or memory on your scheduler. This should be set to n-1 where n is the number of CPUs of your scheduler.
+
+> **Note:** In Airflow 1.10.13 and prior versions, the parsing_processes setting is called max_threads.
 
 On Astronomer, simply increase the slider on the Scheduler to increase CPU and memory.
 


### PR DESCRIPTION
Closes https://github.com/astronomer/docs/issues/213 .

In Airflow 1.10.14, the max_threads variable was renamed to parsing_processes. This PR replaces references to max_threads in Airflow guides where it's referenced. 

I was unsure of how much support we want to offer for previous Airflow versions in guides, so as a precaution I included notes explaining the change (For anyone still on 1.10.13). Feel free to axe these if you don't think they're necessary.

While I was in here, I also did a cheeky title update: When a preposition is part of a phrasal verb (e.g. working out, breaking down), it functions as part of the verb and should be capitalized.