### PR TITLE
Fixed an improper image reference in the 'Get Started' guide

### DIFF
--- a/guides/get-started-airflow-2.md
+++ b/guides/get-started-airflow-2.md
@@ -75,7 +75,7 @@ Your `Dockerfile` will include reference to a Debian-based, [Astronomer Certifie
 In your Dockerfile, replace the existing FROM statement with:
 
 ```dockerfile
-FROM quay.io/astronomer/ap-airflow:2.0.0-buster-onbuild
+FROM quay.io/astronomer/ap-airflow:2.0.0-2-buster-onbuild
 ```
 
 Feel free to refer to the [Astronomer Certified 2.0.0 image source](https://github.com/astronomer/ap-airflow/tree/master/2.0.0/buster).


### PR DESCRIPTION
Resolves https://github.com/astronomer/docs/issues/229

Very quick fix on "Get Started with Apache Airflow 2.0". According to @krisdock , one of the images we use here can cause an uninitialized db error. This change updates the guide to point to a more reliable image. 