### PR TITLE
replace links to Airflow source code with links to registry

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -1437,6 +1437,11 @@ parameterize
 SnowflakeOperator
 param
 S3toSnowflakeTransferOperator
+MssqlHook
+GCSToBigQueryOperator
+PostgresToGCSOperator
+BaseSQLToGCSOperator
+VerticaToMySqlOperator
 - guides/airflow-talend-integration.md
 www.talend.com
 how-to-deploy-talend-jobs-as-docker-images-to-amazon-azure-and-google-cloud-registries

--- a/guides/airflow-azure-container-instances.md
+++ b/guides/airflow-azure-container-instances.md
@@ -16,7 +16,7 @@ tags: ["Integrations", "Azure", "DAGs"]
 
 ### The Azure Container Instances Operator
 
-The easiest way to orchestrate Azure Container Instances with Airflow is to use the [AzureContainerInstancesOperator](https://airflow.apache.org/docs/apache-airflow/stable/_modules/airflow/contrib/operators/azure_container_instances_operator.html). This operator starts a container on ACI, runs the container, and terminates the container when all processes are completed. 
+The easiest way to orchestrate Azure Container Instances with Airflow is to use the [AzureContainerInstancesOperator](https://registry.astronomer.io/providers/microsoft-azure/modules/azurecontainerinstancesoperator). This operator starts a container on ACI, runs the container, and terminates the container when all processes are completed. 
 
 The only prerequisites for using this operator are:
 
@@ -24,7 +24,7 @@ The only prerequisites for using this operator are:
 - An [Azure Service Principle](https://docs.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals) that has write permissions over that resource group
 - A docker image to use for the container (either publicly or privately available)
 
-This operator can also be used to run existing container instances and make certain updates, including the docker image, environment variables, or commands. Some updates to existing container groups are not possible with the operator, including CPU, memory, and GPU; those updates require deleting the existing container group and recreating it, which can be accomplished using the [AzureContainerInstanceHook](https://github.com/apache/airflow/blob/master/airflow/providers/microsoft/azure/hooks/azure_container_instance.py).
+This operator can also be used to run existing container instances and make certain updates, including the docker image, environment variables, or commands. Some updates to existing container groups are not possible with the operator, including CPU, memory, and GPU; those updates require deleting the existing container group and recreating it, which can be accomplished using the [AzureContainerInstanceHook](https://registry.astronomer.io/providers/microsoft-azure/modules/azurecontainerinstancehook).
 
 ### When to use ACI
 
@@ -35,7 +35,7 @@ If you are not running on [AKS](https://azure.microsoft.com/en-us/services/kuber
 - It's easy to use and requires little setup
 - You can run containers in different regions
 - It's typically the cheapest; since no virtual machines or higher-level services are required, **you only pay for the memory and CPU used by your container group while it is active**
-- Unlike the [DockerOperator](https://airflow.apache.org/docs/apache-airflow/1.10.4/_api/airflow/operators/docker_operator/index.html), it does not require running a container on the host machine
+- Unlike the [DockerOperator](https://registry.astronomer.io/providers/docker/modules/dockeroperator), it does not require running a container on the host machine
 
 With these points in mind, we recommend using ACI with the AzureContainerInstancesOperator for testing or lightweight tasks that don't require scaling. For heavy production workloads, we recommend sticking with AKS and the KubernetesPodOperator.
 

--- a/guides/airflow-azure-data-explorer.md
+++ b/guides/airflow-azure-data-explorer.md
@@ -12,7 +12,7 @@ tags: ["Integrations", "Azure", "DAGs"]
 
 [Azure Data Explorer](https://azure.microsoft.com/en-us/services/data-explorer/) (ADX) is a managed data analytics service used for performing real-time analysis of large volumes of streaming data. It's particularly useful for IoT applications, big data logging platforms, and SaaS applications. 
 
-Using Airflow's built-in Azure Data Explorer [Hook](http://airflow.apache.org/docs/apache-airflow-providers-microsoft-azure/stable/_api/airflow/providers/microsoft/azure/hooks/adx/index.html) and [Operator](http://airflow.apache.org/docs/apache-airflow-providers-microsoft-azure/stable/_api/airflow/providers/microsoft/azure/operators/adx/index.html), you can easily integrate ADX queries into your DAGs. In this guide, we'll describe how to make your ADX cluster to work with Airflow and walk through an example DAG that runs a query against a database in that cluster. 
+Using Airflow's built-in Azure Data Explorer [Hook](https://registry.astronomer.io/providers/microsoft-azure/modules/azuredataexplorerhook) and [Operator](https://registry.astronomer.io/providers/microsoft-azure/modules/azuredataexplorerqueryoperator), you can easily integrate ADX queries into your DAGs. In this guide, we'll describe how to make your ADX cluster to work with Airflow and walk through an example DAG that runs a query against a database in that cluster. 
 
 If you don't already have an ADX cluster running and want to follow along with this example, you can find instructions for creating a cluster and loading it with some demo data in [Microsoft's documentation](https://docs.microsoft.com/en-us/azure/data-explorer/create-cluster-database-portal). 
 
@@ -38,7 +38,7 @@ The required pieces for the connection are:
 - **Password:** your client secret
 - **Extra:** should include at least "tenant" with your tenant ID, and "auth_method" with your chosen authentication method. Based on the auth method, you may also need to specify "certificate" and/or "thumbprint" parameters.
 
-For more information on setting up this connection, including available authentication methods, see the [ADX hook documentation](https://github.com/apache/airflow/blob/master/airflow/providers/microsoft/azure/hooks/adx.py).
+For more information on setting up this connection, including available authentication methods, see the [ADX hook documentation](https://registry.astronomer.io/providers/microsoft-azure/modules/azuredataexplorerhook).
 
 Next, we define our DAG:
 

--- a/guides/airflow-databricks.md
+++ b/guides/airflow-databricks.md
@@ -12,7 +12,7 @@ tags: ["Integrations", "DAGs"]
 
 [Databricks](https://databricks.com/) is a popular unified data and analytics platform built around [Apache Spark](https://spark.apache.org/) that provides users with fully managed Apache Spark clusters and interactive workspaces. At Astronomer we believe that best practice is to use Airflow primarily as an orchestrator, and to use an execution framework like Apache Spark to do the heavy lifting of data processing. It follows that using Airflow to orchestrate Databricks jobs is a natural solution for many common use cases.
 
-Astronomer has many customers who use Databricks to run jobs as part of complex pipelines. This can easily be accomplished by leveraging the [Databricks provider](https://github.com/apache/airflow/tree/master/airflow/providers/databricks), which includes Airflow hooks and operators that are actively maintained by the Databricks and Airflow communities. In this guide, we'll discuss the hooks and operators available for interacting with Databricks clusters and run jobs, and we'll show an example of how to use both available operators in an Airflow DAG.
+Astronomer has many customers who use Databricks to run jobs as part of complex pipelines. This can easily be accomplished by leveraging the [Databricks provider](https://registry.astronomer.io/providers/databricks), which includes Airflow hooks and operators that are actively maintained by the Databricks and Airflow communities. In this guide, we'll discuss the hooks and operators available for interacting with Databricks clusters and run jobs, and we'll show an example of how to use both available operators in an Airflow DAG.
 
 ## Databricks Hooks and Operators
 
@@ -22,7 +22,7 @@ The Databricks provider package includes many hooks and operators that allow use
 
 ### Hooks
 
-Using the [Databricks hook](https://github.com/apache/airflow/blob/master/airflow/providers/databricks/hooks/databricks.py) is the best way to interact with a Databricks cluster or job from Airflow. The hook has methods to submit and run jobs to the Databricks REST API, which are used by the operators described below. There are also additional methods users can leverage to:
+Using the [Databricks hook](https://registry.astronomer.io/providers/databricks/modules/databrickshook) is the best way to interact with a Databricks cluster or job from Airflow. The hook has methods to submit and run jobs to the Databricks REST API, which are used by the operators described below. There are also additional methods users can leverage to:
 
 - Get information about runs or jobs
 - Cancel, start, or terminate a cluster
@@ -38,7 +38,7 @@ There are currently two operators in the Databricks provider package:
 The `DatabricksRunNowOperator` should be used when you have an existing job defined in your Databricks workspace that you want to trigger using Airflow. The `DatabricksSubmitRunOperator` should be used if you want to manage the definition of your Databricks job and its cluster configuration within Airflow. Both operators allow you to run the job on a Databricks General Purpose cluster you've already created or on a separate Job Cluster that is created for the job and terminated upon the job’s completion. 
 
 
-Both operators are thoroughly documented in the [provider code](https://github.com/apache/airflow/blob/master/airflow/providers/databricks/operators/databricks.py); we recommend reading through the doc strings on both operators to get familiar with them.
+Documentation for both operators can be found [here](https://registry.astronomer.io/providers/databricks?type=operators).
 
 ## Example - Using Airflow with Databricks
 

--- a/guides/airflow-sql-tutorial.md
+++ b/guides/airflow-sql-tutorial.md
@@ -66,7 +66,7 @@ In Airflow, action operators execute a function. You can use action operators (o
 
 Transfer operators move data from a source to a destination. For SQL-related tasks, they can often be used in the 'Extract-Load' portion of an ELT pipeline and can significantly reduce the amount of code you need to write. Some examples are:
 
-- [S3ToSnowflakeTransferOperator](https://registry.astronomer.io/providers/snowflake/modules/s3tosnowflakeoperator_)
+- [S3ToSnowflakeTransferOperator](https://registry.astronomer.io/providers/snowflake/modules/s3tosnowflakeoperator)
 - [S3toRedshiftOperator](https://registry.astronomer.io/providers/amazon/modules/s3toredshiftoperator)
 - [GCSToBigQueryOperator](https://registry.astronomer.io/providers/google/modules/gcstobigqueryoperator)
 - [PostgresToGCSOperator](https://registry.astronomer.io/providers/google/modules/postgrestogcsoperator)

--- a/guides/airflow-sql-tutorial.md
+++ b/guides/airflow-sql-tutorial.md
@@ -54,24 +54,24 @@ Airflow has many operators available out of the box that make working with SQL e
 
 ### Action Operators
 
-In Airflow, action operators execute a function. You can use action operators to execute a SQL query against a database. Commonly used SQL-related action operators include:
+In Airflow, action operators execute a function. You can use action operators (or hooks if no operator is availble) to execute a SQL query against a database. Commonly used SQL-related action operators include:
 
-- PostgresOperator
-- MssqlOperator
-- MysqlOperator
-- SnowflakeOperator
-- BigQueryOperator
+- [PostgresOperator](https://registry.astronomer.io/providers/postgres/modules/postgresoperator)
+- [MssqlHook](https://registry.astronomer.io/providers/mssql/modules/mssqlhook)
+- [MysqlOperator](https://registry.astronomer.io/providers/mysql/modules/mysqloperator)
+- [SnowflakeOperator](https://registry.astronomer.io/providers/snowflake/modules/snowflakeoperator)
+- [BigQueryOperator](https://registry.astronomer.io/providers/google/modules/bigqueryexecutequeryoperator)
 
 ### Transfer Operators
 
 Transfer operators move data from a source to a destination. For SQL-related tasks, they can often be used in the 'Extract-Load' portion of an ELT pipeline and can significantly reduce the amount of code you need to write. Some examples are:
 
-- S3ToSnowflakeTransferOperator
-- S3toRedshiftOperator
-- GoogleCloudStorageToBigQueryOperator
-- PostgresToGoogleCloudStorageOperator
-- BaseSQLToGoogleCloudStorageOperator
-- VerticaToMySqlTransfer
+- [S3ToSnowflakeTransferOperator](https://registry.astronomer.io/providers/snowflake/modules/s3tosnowflakeoperator_)
+- [S3toRedshiftOperator](https://registry.astronomer.io/providers/amazon/modules/s3toredshiftoperator)
+- [GCSToBigQueryOperator](https://registry.astronomer.io/providers/google/modules/gcstobigqueryoperator)
+- [PostgresToGCSOperator](https://registry.astronomer.io/providers/google/modules/postgrestogcsoperator)
+- [BaseSQLToGCSOperator](https://registry.astronomer.io/providers/google/modules/basesqltogcsoperator)
+- [VerticaToMySqlOperator](https://registry.astronomer.io/providers/mysql/modules/verticatomysqloperator)
 
 ## Examples
 
@@ -79,7 +79,7 @@ With those basic concepts in mind, we'll show a few examples of common SQL use c
 
 ### Example 1 - Executing a Query
 
-In this first example, we use a DAG to execute two simple interdependent queries. To do so we use the [SnowflakeOperator](https://airflow.apache.org/docs/apache-airflow/1.10.14/_api/airflow/contrib/operators/snowflake_operator/index.html). 
+In this first example, we use a DAG to execute two simple interdependent queries. To do so we use the [SnowflakeOperator](https://registry.astronomer.io/providers/snowflake/modules/snowflakeoperator). 
 
 First we need to define our DAG:
 
@@ -220,7 +220,7 @@ WHERE date = {{ params.date }}
 
 Our next example loads data from an external source into a table in our database. We grab data from an API and save it to a flat file on S3, which we then load into Snowflake. 
 
-We use the [S3toSnowflakeTransferOperator](https://github.com/apache/airflow/blob/master/airflow/providers/snowflake/transfers/s3_to_snowflake.py) to limit the code we have to write. 
+We use the [S3toSnowflakeTransferOperator](https://registry.astronomer.io/providers/snowflake/modules/s3tosnowflakeoperator) to limit the code we have to write. 
 
 First, we create a DAG that pulls COVID data from an [API endpoint](https://covidtracking.com/data/api) for California, Colorado, Washington, and Oregon, saves the data to comma-separated values (CSVs) on S3, and loads each of those CSVs to Snowflake using the transfer operator. Here's the DAG code:
 

--- a/guides/airflow-sql-tutorial.md
+++ b/guides/airflow-sql-tutorial.md
@@ -54,7 +54,7 @@ Airflow has many operators available out of the box that make working with SQL e
 
 ### Action Operators
 
-In Airflow, action operators execute a function. You can use action operators (or hooks if no operator is availble) to execute a SQL query against a database. Commonly used SQL-related action operators include:
+In Airflow, action operators execute a function. You can use action operators (or hooks if no operator is available) to execute a SQL query against a database. Commonly used SQL-related action operators include:
 
 - [PostgresOperator](https://registry.astronomer.io/providers/postgres/modules/postgresoperator)
 - [MssqlHook](https://registry.astronomer.io/providers/mssql/modules/mssqlhook)

--- a/guides/airflow-talend-integration.md
+++ b/guides/airflow-talend-integration.md
@@ -41,7 +41,7 @@ Each method has pros and cons, and the method you choose will likely depend on y
 
 ## Executing Talend Jobs Using the Cloud API
 
-The first way of executing Talend jobs from Airflow is using the Talend Cloud API via the SimpleHttpOperator in Airflow. This method is ideal if you have Talend Cloud jobs that do not have downstream dependencies.
+The first way of executing Talend jobs from Airflow is using the Talend Cloud API via the [SimpleHttpOperator](https://registry.astronomer.io/providers/http/modules/simplehttpoperator) in Airflow. This method is ideal if you have Talend Cloud jobs that do not have downstream dependencies.
 
 Below we will show how to configure your Talend Cloud account to work with the API, and an example DAG that will execute a workflow. If you are unfamiliar with the Talend Cloud API, the documentation at these links are helpful: 
 
@@ -123,7 +123,7 @@ Finally, note that because the API call will simply trigger the job, the Airflow
 
 ## Executing Talend Jobs with KubernetesPodOperator
 
-The second way to execute Talend jobs with Airflow is to containerize them and execute them from Airflow using the KubernetesPodOperator. This is a good option if you are using Talend studio, and if you have tasks that are dependent on your Talend jobs completing first.
+The second way to execute Talend jobs with Airflow is to containerize them and execute them from Airflow using the [KubernetesPodOperator](https://registry.astronomer.io/providers/kubernetes/modules/kubernetespodoperator). This is a good option if you are using Talend studio, and if you have tasks that are dependent on your Talend jobs completing first.
 
 Here we'll show how to containerize an existing Talend job, and then execute some containerized jobs with dependencies using the KubernetesPodOperator in Airflow.
 

--- a/guides/trigger-dag-operator.md
+++ b/guides/trigger-dag-operator.md
@@ -11,9 +11,8 @@ As workflows are being developed and built upon by different team members, they 
 
 The first level of complexity can usually be handled by some sort of error messaging - throw an error notification to a particular person or group based on a workflow's failure.
 
-Branching can be helpful for performing conditional logic - execute a set of tasks based off of a condition. For situations where that is not enough - **The TriggerDagRunOperator can be used to kick off entire DAGs.**
+Branching can be helpful for performing conditional logic - execute a set of tasks based off of a condition. For situations where that is not enough - **The [TriggerDagRunOperator](https://registry.astronomer.io/providers/apache-airflow/modules/triggerdagrunoperator) can be used to kick off entire DAGs.**
 
-`https://github.com/apache/incubator-airflow/blob/master/airflow/operators/dagrun_operator.py`
 
 ## Define a controller and a target  DAG
 


### PR DESCRIPTION
@petedejoy went through guides where I knew I had links to Airflow hook/operator source code and updated them to point to the registry. Possible there are some I missed in some of the older guides, but figured those probably need more thorough review anyway and this would be a good start.