### PR TITLE
Updating guide for grammatical and spelling consistency + Task Group note

### DIFF
--- a/guides/subdags.md
+++ b/guides/subdags.md
@@ -7,19 +7,23 @@ heroImagePath: null
 tags: ["DAGs", "Subdags"]
 ---
 <!-- markdownlint-disable-file -->
+> **Note:** Astronomer highly recommends staying away from SubDAGs if the intended use of the SubDAG is to simply group tasks within a DAG's Graph View.  Airflow 2.0 introduces [Task Groups](https://airflow.apache.org/docs/apache-airflow/stable/concepts.html#taskgroup) which is a UI grouping concept that satisfies this purpose without the performance and functional issues of SubDAGs.  While the SubDagOperator will continue to be supported, Task Groups are intended to replace it long-term.
+
+
 Most DAGs consist of patterns that often repeat themselves. ETL DAGs that are written to best practice usually all share the pattern of grabbing data from a source, loading it to an intermediary file store or _staging_ table, and then pushing it into production data.
 
-Depending on your set up, using a subdag operator could make your DAG cleaner.
+Depending on your set up, using a [SubDagOperator](https://registry.astronomer.io/providers/apache-airflow/modules/subdagoperator) could make your DAG cleaner.
+
 
 Suppose the DAG looks like:
 
 ![no_subdag](https://assets.astronomer.io/website/img/guides/workflow_no_subdag.png)
 
-The pattern between extracting and loading the data is clear. The same workflow can be generated through subdags:
+The pattern between extracting and loading the data is clear. The same workflow can be generated through SubDAGs:
 
 ![subdag](https://assets.astronomer.io/website/img/guides/subdag_dag.png)
 
-Each of the subdags can be zoomed in on:
+Each of the SubDAGs can be zoomed in on:
 
 ![zoom](https://assets.astronomer.io/website/img/guides/zoomed_in.png)
 
@@ -27,7 +31,7 @@ The zoomed view reveals a granular view of the task:
 
 ![tasks](https://assets.astronomer.io/website/img/guides/subdag_tasks.png)
 
-Subdags should be generated through a "DAG factory" - an external file that returns dag objects.
+SubDAGs should be generated through a "DAG factory" - an external file that returns DAG objects.
 
 ```python
 def load_subdag(parent_dag_name, child_dag_name, args):
@@ -52,30 +56,35 @@ This object should then be called when instantiating the SubDagOperator:
 
 ```python
 load_tasks = SubDagOperator(
-        task_id='load_tasks',
-        subdag=load_subdag('example_subdag_operator',
-                           'load_tasks', default_args),
-        default_args=default_args,
-        dag=dag,
-    )
+    task_id="load_tasks",
+    subdag=load_subdag(
+        parent_dag_name="example_subdag_operator",
+        child_dag_name="load_tasks",
+        args=default_args
+    ),
+    default_args=default_args,
+    dag=dag,
+)
+
 ```
 
-- The subdag should be named with a `parent.child` style or Airflow will throw an error.
+- The SubDAG should be named with a `parent.child` style or Airflow will throw an error.
 - The state of the SubDagOperator and the tasks themselves are independent - a SubDagOperator marked as success (or failed) will not affect the underlying tasks._This can be dangerous_
-- SubDags should be scheduled the same as their parent DAGs or unexpected behavior might occur.
+- SubDAGs should be scheduled the same as their parent DAGs or unexpected behavior might occur.
 
 ## Avoiding Deadlock
 
 _Greedy subdags_
 
-SubDags are not currently first class citizens in Airflow. Although it is in the community's roadmap to fix this, many organizations using Airflow have outright banned them because of how they are executed.
+SubDAGs are not currently first-class citizens in Airflow. Although it is in the community's roadmap to fix this, many organizations using Airflow have outright banned them because of how they are executed.
+
+Airflow 1.10 has changed the default SubDAG execution method to use the Sequential Executor to work around deadlocks caused by SubDAGs.
+
 
 ### Slots on the worker pool
 
-The SubDagOperator kicks off an entire DAG when it is put on a worker slot. Each task in the child DAG takes up a slot until the entire SubDag has completed. The parent operator will take up a worker slot until each child task has completed. This could cause delays in other task processing
+The SubDagOperator kicks off an entire DAG when it is put on a worker slot. Each task in the child DAG takes up a slot until the entire SubDAG has completed. The parent operator will take up a worker slot until each child task has completed. This could cause delays in other task processing
 
-In mathematical terms, each SubDag is behaving like a _vertex_ (a single point in a graph) instead of a _graph_.
+In mathematical terms, each SubDAG is behaving like a _vertex_ (a single point in a graph) instead of a _graph_.
 
-Depending on the scale and infrastructure, a specialized queue can be added just for SubDags (assuming a CeleryExecutor), but a cleaner workaround is to avoid subdags entirely.
-
-**Astronomer highly recommends staying away from SubDags. Airflow 1.10 has changed the default SubDag execution method to use the Sequential Executor to work around deadlocks caused by SubDags**
+Depending on the scale and infrastructure, a specialized queue can be added just for SubDAGs (assuming a CeleryExecutor), but a cleaner workaround is to avoid SubDAGs entirely.


### PR DESCRIPTION
- Added recommendation for Task Group which includes a link to the Airflow documentation on said feature
- Updated spelling of SubDAG to be consistent across the document and consistent with other existing guides
- Added a link to the SubDagOperator module in the Astronomer Registry
- Reformatted SubDagOperator code snippet to have a short line length
- Small rearrangement of documentation under the Avoiding Deadlocks section