### PR TITLE
Re-write "Scaling Out Airflow" Guide

### DIFF
--- a/guides/airflow-scaling-workers.md
+++ b/guides/airflow-scaling-workers.md
@@ -76,7 +76,7 @@ To check current values for an existing Airflow environment, navigate to **Admin
 
   This number is limited by `dag_concurrency`. If you have 1 Worker and want it to match your environment's capacity, `worker_concurrency` should be equal to `parallelism`. If you increase `worker_concurrency`, you might also need to provision additional CPU and/or memory for your Workers.   
 
-- **`parsing_processes`** is the maximum number of threads that can run on the Airflow Scheduler at once. Increasing the value of `parallelism` results in additional strain on the Scheduler, so we recommend increasing `parsing_processes` as well. If you notice a delay in tasks being scheduled, you might need to increase this value or provision additional resources for your Scheduler.
+- **`parsing_processes`** is the maximum number of threads that can run on the Airflow Scheduler at once. Increasing the value of `parallelism` results in additional strain on the Scheduler, so we recommend increasing `parsing_processes` as well. If you notice a delay in tasks being scheduled, you might need to increase this value or provision additional resources for your Scheduler. If you're running on Astronomer, read [Configure your Airflow Deployment](https://www.astronomer.io/docs/cloud/stable/deploy/configure-deployment#scale-core-resources) for more information on scaling up your Scheduler.
 
     > **Note:** This setting was renamed in Airflow 1.10.14. In earlier versions, it is defined as `max_threads` ([source](https://github.com/apache/airflow/commit/486134426bf2cd54fae1f75d9bd50715b8369ca1)).
 
@@ -145,3 +145,5 @@ To create a pool:
       pool='My_REST_API'
     )
   ```
+
+> **Note:** If you're developing locally with the Astronomer CLI, you can define Airflow Pools in the `airflow_settings.yaml` file that was automatically generated when you initialized your Airflow project with `$ astro dev init`. This file allow you to set Pools, Variables, and Connections in a single file such that you don't have to manually re-create them in the Airflow UI every time you restart your environment. For more information, read [Customize your Airflow Image on Astronomer](https://www.astronomer.io/docs/cloud/stable/develop/customize-image#configure-airflowsettingsyaml).

--- a/guides/airflow-scaling-workers.md
+++ b/guides/airflow-scaling-workers.md
@@ -10,7 +10,7 @@ tags: ["Workers", "Concurrency", "Parallelism", "DAGs"]
 
 ## Overview
 
-One of Apache Airflow's biggest strengths is its ability to scale as the needs of your team grow. To make the most of Airflow's extensibility, there are a few key settings that you should consider modifying as you scale up your data pipelines.
+One of Apache Airflow's biggest strengths is its scalability. To make the most of Airflow, there are a few key settings that you should consider modifying as you scale up your data pipelines.
 
 Airflow exposes a number of parameters that are closely related to DAG and task-level performance. These fall into 3 categories:
 
@@ -24,9 +24,9 @@ In this guide, we'll walk through key values in each category in the context of 
 
 ## Environment-level Airflow Settings
 
-Environment-level settings are typically set in the `airflow.cfg` file, which is required in all Airflow projects. All settings in this file have a default value that can be overriden by modifying the file directly. Default values are taken from the [default_airflow.cfg file](https://github.com/apache/airflow/blob/master/airflow/config_templates/default_airflow.cfg) in Airflow project source code.
+Environment-level settings are typically set in the `airflow.cfg` file, which is required in all Airflow projects. All settings in this file have a default value that can be overridden by modifying the file directly. Default values are taken from the [default_airflow.cfg file](https://github.com/apache/airflow/blob/master/airflow/config_templates/default_airflow.cfg) in Airflow project source code.
 
-To check current values for an existing Airflow environment, navigate to **Admin** > **Configurations** in the Airflow UI. For more information, read [Setting Configuration Options](https://airflow.apache.org/docs/apache-airflow/stable/howto/set-config.html) or [Configuration Reference](https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html) in Airflow documentation.
+To check current values for an existing Airflow environment, go to **Admin** > **Configurations** in the Airflow UI. For more information, read [Setting Configuration Options](https://airflow.apache.org/docs/apache-airflow/stable/howto/set-config.html) or [Configuration Reference](https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html) in Airflow documentation.
 
 > **Note:** If you're running on Astronomer, these settings can be modified via Environment Variables. For more information, read [Environment Variables on Astronomer](https://www.astronomer.io/docs/cloud/stable/deploy/environment-variables).
 
@@ -146,4 +146,4 @@ To create a pool:
     )
   ```
 
-> **Note:** If you're developing locally with the Astronomer CLI, you can define Airflow Pools in the `airflow_settings.yaml` file that was automatically generated when you initialized your Airflow project with `$ astro dev init`. This file allow you to set Pools, Variables, and Connections in a single file such that you don't have to manually re-create them in the Airflow UI every time you restart your environment. For more information, read [Customize your Airflow Image on Astronomer](https://www.astronomer.io/docs/cloud/stable/develop/customize-image#configure-airflowsettingsyaml).
+> **Note:** If you're developing locally with the Astronomer CLI, you can define Airflow Pools in the `airflow_settings.yaml` file that was automatically generated when you initialized your Airflow project with `$ astro dev init`. You can use this file to set Pools, Variables, and Connections without needing to manually recreate them in the Airflow UI whenever you restart your environment. For more information, read [Customize your Airflow Image on Astronomer](https://www.astronomer.io/docs/cloud/stable/develop/customize-image#configure-airflowsettingsyaml).

--- a/guides/airflow-scaling-workers.md
+++ b/guides/airflow-scaling-workers.md
@@ -92,7 +92,7 @@ If all of these tasks exist within a single DAG and `dag_concurrency=16`, howeve
 
 There are two primary DAG-level Airflow settings users can define in code:
 
-- **`max_active_run`** is the maximum number of active DAG Runs allowed for the DAG in question. Once this limit is hit, the Scheduler will not create new active DAG Runs. If this setting is not defined, the value of `max_active_runs_per_dag` (described above) is assumed.
+- **`max_active_runs`** is the maximum number of active DAG Runs allowed for the DAG in question. Once this limit is hit, the Scheduler will not create new active DAG Runs. If this setting is not defined, the value of `max_active_runs_per_dag` (described above) is assumed.
 
   ```
   # Allow a maximum of 3 active runs of this DAG at any given time


### PR DESCRIPTION
The Scaling Airflow guide, one of the most commonly visited guides, was not in great shape. So far this PR only encompasses wording and style changes, but I'm hoping to add more technical details or updates as needed. 

I took out most of the references to Astronomer because the screenshots were pre 0.13, but definitely want to reintroduce them at some point. Interested to hear thoughts on how we should mention Astronomer features in Airflow guides, as it doesn't seem like what we had before was best practice.