### PR TITLE
Fixing markdown synatx error

### DIFF
--- a/guides/airflow-sql-tutorial.md
+++ b/guides/airflow-sql-tutorial.md
@@ -445,6 +445,6 @@ In this guide we covered how to interact with your SQL database from Airflow and
 - What if you want to retrieve data with the PostgresOperator?
 - Is it scalable?
 
-Find out more on Astronomer's ![Academy Course on Airflow SQL](https://academy.astronomer.io/airflow-sql) for free today.
+Find out more on Astronomer's [Academy Course on Airflow SQL](https://academy.astronomer.io/airflow-sql) for free today.
 
 See you there! ❤️


### PR DESCRIPTION
This PR fixes a small error with the markdown syntax where it should be a hyperlink instead of an image.