### PR TITLE
Fix language declarations

### DIFF
--- a/guides/dynamically-generating-dags.md
+++ b/guides/dynamically-generating-dags.md
@@ -296,7 +296,7 @@ with dag:
 
 Next we create a `dag-config` folder that will contain a JSON config file for each DAG. The config file should define the parameters that we noted above, the DAG Id, schedule interval, and query to be executed.
 
-```Json
+```json
 {
     "DagId": "dag_file_1",
     "Schedule": "'@daily'",

--- a/guides/kerberos.md
+++ b/guides/kerberos.md
@@ -39,7 +39,7 @@ We recommend using built-in hooks with Kerberos support if they work for your us
 
 Settings for Kerberos can be configured via the `[kerberos]` group in `airflow.cfg`:
 
-```
+```toml
 [kerberos]
 ccache = /tmp/airflow_krb5_ccache
 # gets augmented with fqdn

--- a/guides/kerberos.md
+++ b/guides/kerberos.md
@@ -39,7 +39,7 @@ We recommend using built-in hooks with Kerberos support if they work for your us
 
 Settings for Kerberos can be configured via the `[kerberos]` group in `airflow.cfg`:
 
-```cfg
+```
 [kerberos]
 ccache = /tmp/airflow_krb5_ccache
 # gets augmented with fqdn

--- a/guides/what-is-an-operator.md
+++ b/guides/what-is-an-operator.md
@@ -18,7 +18,7 @@ When you create an instance of an operator in a DAG and provide it with it's req
 
 ### BashOperator
 
-```Python
+```python
 t1 = BashOperator(
         task_id='bash_hello_world',
         dag=dag,


### PR DESCRIPTION
This small updates changes `Json` and `Python` to `json` and `python` to fix a build error on the site.

Update: Replaced `cfg` with `toml` since it should have similar/the same syntax highlighting and to pass markdown-lint.