### PR TITLE
minor changes for clarification

### DIFF
--- a/guides/airflow-importing-custom-hooks-operators.md
+++ b/guides/airflow-importing-custom-hooks-operators.md
@@ -23,7 +23,7 @@ At a high level, creating a custom operator is straightforward. At a minimum, al
 This will look something like the code below:
 
 ```python
-from airflow.operators.bash_operator import BaseOperator
+from airflow.models.baseoperator import BaseOperator
 from airflow.utils.decorators import apply_defaults
 from hooks.my_hook import MyHook
 
@@ -61,7 +61,7 @@ Airflow by default will add the `dags/` and `plugins/` directories in a project 
 │       └── transforms.sql
 ├── packages.txt     
 ├── plugins/             
-│   └── hooks/
+│   └── operators/
 │       └── my_operator.py
 │   └── sensors/
 │       └── my_sensor.py


### PR DESCRIPTION
1. bash_operator was being imported rather than baseoperator
2. the example dag uses `from operators.my_operator import MyOperator` but the tree diagram has `my_operator.py` under `hooks/` instead of `operators/`