### PR TITLE
Update ADF guide with new Azure provider modules

### DIFF
--- a/guides/airflow-azure-data-factory-integration.md
+++ b/guides/airflow-azure-data-factory-integration.md
@@ -25,13 +25,13 @@ That's where Airflow comes in. ADF jobs can be run using an Airflow DAG, giving 
 
 ## ADF Modules in Airflow
 
-The [Microsoft Azure provider](https://registry.astronomer.io/providers/microsoft-azure) has multiple modules for orchestrating ADF pipelines from Airflow.
+The [Microsoft Azure provider](https://registry.astronomer.io/providers/microsoft-azure) has multiple modules for orchestrating ADF pipelines with Airflow.
 
-- [`AzureDataFactoryHook`](https://registry.astronomer.io/providers/microsoft-azure/modules/azuredatafactoryhook): Abstracts the ADF API and provides an easy way of connecting to ADF from Airflow.
-- [`AzureDataFactoryRunPipelineOperator`](https://registry.astronomer.io/providers/microsoft-azure/modules/azuredatafactoryrunpipelineoperator): Executes an ADF pipeline.
-- [`AzureDataFactoryPipelineRunStatusSensor`](https://registry.astronomer.io/providers/microsoft-azure/modules/azuredatafactorypipelinerunstatussensor): Waits for an ADF pipeline run to complete.
+- [`AzureDataFactoryHook`](https://registry.astronomer.io/providers/microsoft-azure/modules/azuredatafactoryhook): Abstracts the ADF API and provides an easy way of connecting to ADF from Airflow
+- [`AzureDataFactoryRunPipelineOperator`](https://registry.astronomer.io/providers/microsoft-azure/modules/azuredatafactoryrunpipelineoperator): Executes an ADF pipeline
+- [`AzureDataFactoryPipelineRunStatusSensor`](https://registry.astronomer.io/providers/microsoft-azure/modules/azuredatafactorypipelinerunstatussensor): Waits for an ADF pipeline run to complete
 
-If the existing operators or sensors are not quite right for your use case, you can use the `AzureDataFactoryHook` in your own Python function to take advantage of any ADF API functionality. Understanding how the [ADF API](https://docs.microsoft.com/en-us/rest/api/datafactory/v1/data-factory-data-factory) works can be helpful when designing your own custom functions, or for gaining a deeper understanding of how the provider modules work.
+If these modules are not quite right for your use case, you can use the `AzureDataFactoryHook` in your own Python function to take advantage of any ADF API functionality. Understanding how the [ADF API](https://docs.microsoft.com/en-us/rest/api/datafactory/v1/data-factory-data-factory) works can be helpful when designing your own custom functions or understanding of how the provider modules work.
 
 ## Example Implementation
 
@@ -43,7 +43,7 @@ Before you can orchestrate your ADF pipelines with Airflow, you have to make tho
 
 > **Note:** If you do not currently have an ADF pipeline in your Azure account and are new to ADF, check out the [ADF quick start docs](https://docs.microsoft.com/en-us/azure/data-factory/quickstart-create-data-factory-portal) for help getting started.
 
-To make your ADF pipeline accessible by Airflow you will need to register an App with Azure Active Directory to get a Client ID and Client Secret (API Key) for your Data Factory. First go to Azure Active Directory and click on 'Registered Apps' to see a list of registered apps. If you created a Resource group you should already have an app registered with the same name.
+To make your ADF pipeline accessible by Airflow you will need to register an App with Azure Active Directory to get a Client ID and Client Secret (API Key) for your Data Factory. First, go to Azure Active Directory and click on 'Registered Apps' to see a list of registered apps. If you created a Resource group, you should already have an app registered with the same name.
 
 ![ADF App Registration](https://assets2.astronomer.io/main/guides/azure-data-factory/adf_app_registration.png)
 
@@ -74,7 +74,7 @@ Additional detail on requirements for interacting with Azure Data Factory using 
 
 ### Create a DAG to Orchestrate ADF Jobs
 
-Now that we have existing ADF pipelines that should be runnable externally to Azure, we will create a DAG that will execute those pipelines using Azure provider modules. The DAG below executes two ADF pipelines in parallel (tasks `run_pipeline1` and `run_pipeline2`). It then uses an `AzureDataFactoryPipelineRunStatusSensor` to wait until "pipeline2" has completed before finishing the DAG.
+Now that our ADF pipelines are runnable, we create a DAG that executes those pipelines using Azure provider modules. The DAG below executes two ADF pipelines in parallel (tasks `run_pipeline1` and `run_pipeline2`). It then uses an `AzureDataFactoryPipelineRunStatusSensor` to wait until "pipeline2" has completed before finishing the DAG.
 
 ```python
 from datetime import datetime, timedelta

--- a/guides/airflow-azure-data-factory-integration.md
+++ b/guides/airflow-azure-data-factory-integration.md
@@ -134,19 +134,10 @@ with DAG(
 
 ![Graph View](https://assets2.astronomer.io/main/guides/azure-data-factory/multiple_adf_pipeline_graph.png)
 
-Note that this DAG requires an `azure_data_factory` [Airflow connection](https://airflow.apache.org/docs/apache-airflow/stable/concepts/connections.html. The connection requires the following information:
+Note that this DAG requires an `azure_data_factory` [Airflow connection](https://www.astronomer.io/guides/connections). The connection requires the following information:
 
-- Tenant ID 
-- Subscription ID
-- Resource Group
-- Factory
-- Client ID
-- Client secret
-
-They should be entered into the connection form like this:
-
-![Airflow ADF Connection](https://assets2.astronomer.io/main/guides/azure-data-factory/adf_airflow_connection.png)
-
-The Client ID is the login, Client Secret is the password, and the rest are JSON-formatted extras.
+- **Login:** Your Azure Client ID
+- **Password:** Your Azure Client secret
+- **Extras:** `{"tenantId":"Your Tenant ID", "subscriptionId":"Your Subscription ID", "resourceGroup":"Your Resource Group", "factory":"Your Factory"}`
 
 For a more complex example of orchestrating dependent ADF pipelines with Airflow, check out [this example](https://registry.astronomer.io/dags/airflow-azure-data-factory) on the Astronomer Registry.

--- a/guides/airflow-azure-data-factory-integration.md
+++ b/guides/airflow-azure-data-factory-integration.md
@@ -134,7 +134,7 @@ with DAG(
 
 ![Graph View](https://assets2.astronomer.io/main/guides/azure-data-factory/multiple_adf_pipeline_graph.png)
 
-Note that this DAG requires an Airflow connection (`azure_data_factory`) to connect to your Azure instance and ADF. The connection requires the following information:
+Note that this DAG requires an `azure_data_factory` [Airflow connection](https://airflow.apache.org/docs/apache-airflow/stable/concepts/connections.html. The connection requires the following information:
 
 - Tenant ID 
 - Subscription ID

--- a/guides/airflow-azure-data-factory-integration.md
+++ b/guides/airflow-azure-data-factory-integration.md
@@ -10,7 +10,7 @@ tags: ["Integrations", "Azure"]
 
 Azure Data Factory (ADF) is a commonly used service for constructing data pipelines and jobs. With a little preparation, it can be used in combination with Airflow to leverage the best of both tools. In this guide, we'll discuss why you might want to use these two tools together, how Airflow can be used to execute ADF jobs, and a simple example tutorial showing how it all fits together.
 
-> **Note:** All code in this guide can be found on [the Astronomer Registry](https://registry.astronomer.io/dags/example-adf-run-pipeline).
+> **Note:** All code in this guide can be found on [the Astronomer Registry](https://registry.astronomer.io/dags/azure-data-factory-dag).
 
 ## Why Use Airflow with ADF
 


### PR DESCRIPTION
@jwitz another small update for you when you have a minute. This guide pre-dated the ADF-specific operators and sensors, so I updated it to mention those modules and replaced the example DAG. 