### PR TITLE
First draft of an update to the KPO guide

### DIFF
--- a/guides/kubepod-operator.md
+++ b/guides/kubepod-operator.md
@@ -47,7 +47,7 @@ The `KubernetesPodOperator` runs any Docker image provided to it, whether they a
 - Having full control over how much compute resources and memory a single task can use.
 - Executing tasks in an separate environment with individual packages and dependencies.
 - Running tasks that necessitate using a version of Python not supported by your Airflow environment.
-- Running tasks with specific Node (a virtual or physical machine in Kubernetes) constrains such as only running on Nodes located in the European Union.
+- Running tasks with specific Node (a virtual or physical machine in Kubernetes) constraints such as only running on Nodes located in the European Union.
 
 Sometimes you may want to run Pods on different clusters, for example if only some need GPU resources while others do not. This is also possible with the KPO and a step-by-step example is provided at the end of this guide.
 
@@ -103,9 +103,9 @@ There are also many other arguments that can be used to configure the Pod and pa
 
 ### Configuring Kubernetes Connection
 
-When leaving the `in_cluster` parameter on its default setting (`True`) it is not necessary to further configure the Kubernetes connection, the Pod specified by the `KubernetesPodOperator` will be run on the same Kubernetes cluster as your Airflow instance is running on.
+When leaving the `in_cluster` parameter on its default setting (`True`) it is not necessary to further configure the Kubernetes connection. The Pod specified by the `KubernetesPodOperator` will be run on the same Kubernetes cluster as your Airflow instance is running on.
 
-If you are not running Airflow on Kubernetes or want to send the Pod to a different cluster than the one currently hosting your Airflow instance the three arguments below will be necessary to specify how the KPO will use the [Kubernetes Hook](https://registry.astronomer.io/providers/kubernetes/modules/kuberneteshook) to connect to the [Kubernetes API](https://kubernetes.io/docs/reference/kubernetes-api/) of a different Kubernetes cluster.
+If you are not running Airflow on Kubernetes or want to send the Pod to a different cluster than the one currently hosting your Airflow instance, the three arguments below will be necessary to specify how the KPO will use the [Kubernetes Hook](https://registry.astronomer.io/providers/kubernetes/modules/kuberneteshook) to connect to the [Kubernetes API](https://kubernetes.io/docs/reference/kubernetes-api/) of a different Kubernetes cluster.
 
 - `kubernetes_conn_id`: uses a [connection](https://www.astronomer.io/guides/connections) stored in the [Airflow metadata database](https://www.astronomer.io/guides/airflow-database), which can be configured in the Airflow UI under **Admin** -> **Connections**.
 - `config_file`: sets the path to the `KubeConfig` file. If not specified, the default value is `~/.kube/config`.

--- a/guides/kubepod-operator.md
+++ b/guides/kubepod-operator.md
@@ -2,46 +2,48 @@
 title: "KubernetesPodOperator on Astronomer"
 description: "Use the KubernetesPodOperator on Astronomer"
 date: 2018-07-17T00:00:00.000Z
-slug: "kubePod-operator"
+slug: "kubepod-operator"
 heroImagePath: null
 tags: ["Kubernetes", "Operators"]
 ---
 
 ## Overview
 
-The [KubernetesPodOperator](https://registry.astronomer.io/providers/kubernetes/modules/kubernetesPodoperator) (KPO) is an operator from the Kubernetes provider package designed to provide a straightforward way to execute a task in a Kubernetes pod from your Airflow environment. In a nutshell, the KPO is an abstraction over a call to the Kubernetes API to launch a pod.
+The [`KubernetesPodOperator`](https://registry.astronomer.io/providers/kubernetes/modules/kubernetespodoperator) (KPO) is an operator from the Kubernetes provider package designed to provide a straightforward way to execute a task in a Kubernetes pod from your Airflow environment. In a nutshell, the KPO is an abstraction over a call to the Kubernetes API to launch a pod.
 
-In this guide, we list the requirements to run the KubernetesPodOperator, explain when to use it and cover its most important arguments, as well as the difference between the KPO and KubernetesExecutor. We also provide concrete examples on how to use the KPO to run a task in a language other than Python, how to use the KPO with XComs, and how to launch a pod in a remote AWS EKS Cluster.  
+In this guide, we list the requirements to run the `KubernetesPodOperator`, explain when to use it and cover its most important arguments, as well as the difference between the KPO and `KubernetesExecutor`. We also provide concrete examples on how to use the KPO to run a task in a language other than Python, how to use the KPO with XComs, and how to launch a pod in a remote AWS EKS Cluster.  
 
 > **Note**: Kubernetes is a powerful tool for Container Orchestration with complex functionality. If you are unfamiliar with Kubernetes we recommend taking a look at the [Kubernetes 101 Guide](https://www.astronomer.io/guides/intro-to-kubernetes/) to get a general overview. For in-depth information check out the [Kubernetes Documentation](https://kubernetes.io/docs/home/).  
 
-## Requirements For Using the KubernetesPodOperator
+## Requirements For Using the `KubernetesPodOperator`
 
-To use the KubernetesPodOperator it is necessary to install the Kubernetes provider package.
+To use the `KubernetesPodOperator` it is necessary to install the Kubernetes provider package.
 
 ```bash
 pip install apache-airflow-providers-cncf-kubernetes==<version>
 ```
 
-Required versions of the `apache-airflow`, `cryptography` and `kubernetes` packages for specific versions of the Kubernetes provider package are listed in the [Airflow Documentation](https://airflow.apache.org/docs/apache-airflow-providers-cncf-kubernetes/stable/index.html#requirements).
+To double check which version of the Kubernetes provider package is compatible with your version of Airflow and to view dependencies that will be installed automatically please refer to the [Airflow Kubernetes provider Documentation](https://airflow.apache.org/docs/apache-airflow-providers-cncf-kubernetes/stable/index.html#requirements).
 
-You will also need an existing Kubernetes cluster to connect to. It is _not_ necessary to use the Kubernetes Executor in order to use the KPO. You may use any of the following executors: `CeleryExecutor`, `KubernetesExecutor`, [`CeleryKubernetesExecutor`](https://airflow.apache.org/docs/apache-airflow/2.0.0/executor/celery_kubernetes.html). When using Celery remember to install its [provider](https://registry.astronomer.io/providers/celery).
+You will also need an existing Kubernetes cluster to connect to, which commonly but not necessarily is the same cluster that Airflow is running on. It is _not_ necessary to use the Kubernetes Executor in order to use the KPO. You may use any of the following executors: `CeleryExecutor`, `KubernetesExecutor`, [`CeleryKubernetesExecutor`](https://airflow.apache.org/docs/apache-airflow/2.0.0/executor/celery_kubernetes.html). When using Celery remember to install its [provider](https://registry.astronomer.io/providers/celery).
 
-> **Note**: On Astro, the infrastructure needed to run KPO with CeleryExecutor is pre-built into every cluster. Astronomer provides [comprehensive documentation on using the KPO on Astro](https://docs.astronomer.io/astro/kubernetesPodoperator).  
+> **Note**: On Astro, the infrastructure needed to run KPO with CeleryExecutor is pre-built into every cluster. Astronomer provides [comprehensive documentation on using the KPO on Astro](https://docs.astronomer.io/astro/kubernetespodoperator).  
 
-### Running the KubernetesPodOperator Locally
+### Running the `KubernetesPodOperator` Locally
 
-There are several ways in which the KubernetesPodOperator can be run in local development. For users of the Astro CLI there is a [step-by-step tutorial](https://docs.astronomer.io/software/kubePodoperator-local) available in the Astro Documentation, which can also be adapted for other dockerized Airflow setups.
+When developing and testing changes it can be tedious to deploy to a remote environment, which is why many users set up their local dev environment to support usage of the KPO. This can be accomplished in several ways.
+
+For users of the Astro CLI there is a [step-by-step tutorial](https://docs.astronomer.io/software/kubePodoperator-local) available in the Astro Documentation, which can also be adapted for other dockerized Airflow setups.
 
 It is also possible to run open source Airflow within a local Kubernetes cluster using the [Helm Chart for Apache Airflow](https://airflow.apache.org/docs/helm-chart/stable/index.html). For a walkthrough of this setup you can refer to the recording of the [Getting Started With the Official Airflow Helm Chart Webinar](https://www.youtube.com/watch?v=39k2Sz9jZ2c&ab_channel=Astronomer).
 
-When running Airflow within a Kubernetes cluster, using the KPO does not require further configuration beyond leaving the setting `in_cluster` on `True` to run a new pod within the same cluster. An example on how to run a pod on a remote cluster, including in the case of not running local Airflow on Kubernetes, is presented at the end of this guide.
+When running Airflow within a Kubernetes cluster, using the KPO does not require further configuration beyond leaving the `KubernetesPodOperator` parameter `in_cluster` on its default setting (`True`) to run a new pod within the same cluster. An example on how to run a pod on a remote cluster, including in the case of not running local Airflow on Kubernetes, is presented at the end of this guide.
 
-## When to use the KubernetesPodOperator
+## When to use the `KubernetesPodOperator`
 
-The KubernetesPodOperator runs any Docker image provided to it, whether they are pulled from [DockerHub](https://hub.docker.com/) or from private repositories. Frequent use cases are:
+The `KubernetesPodOperator` runs any Docker image provided to it, whether they are pulled from [DockerHub](https://hub.docker.com/) or from private repositories. Frequent use cases are:
 
-- Running a task better described in a language other than Python. For an example see the section 'Example: Using the KubernetesPodOperator to run a script in Haskell' below.
+- Running a task better described in a language other than Python. For an example see the section 'Example: Using the `KubernetesPodOperator` to run a script in Haskell' below.
 - Having full control over how much compute resources and memory a single task can use.
 - Executing tasks in an separate environment with individual packages and dependencies.
 - Running tasks that necessitate using a version of Python not supported by your Airflow environment.
@@ -51,76 +53,71 @@ Sometimes you may want to run pods on different clusters, for example if only so
 
 > **Note**: A simple way to execute tasks in different clusters with different compute resources using worker queues is an upcoming feature on Astro!
 
-### KubernetesPodOperator vs KubernetesExecutor
+### `KubernetesPodOperator` vs `KubernetesExecutor`
 
 In Airflow you have the option to choose between a variety of [executors](https://www.astronomer.io/guides/airflow-executors-explained) which determine how your Airflow tasks will be executed.
 
-The [KubernetesExecutor](https://airflow.apache.org/docs/apache-airflow/stable/executor/kubernetes.html) and the KubernetesPodOperator both dynamically launch and terminate pods to run Airflow tasks. As the names suggest, KubernetesExecutor is an executor, which means it affects how all tasks in an Airflow instance are executed, while the KubernetesPodOperator is an operator defining that a single task is to be launched in a Kubernetes Pod with the given configuration and does not affect any other tasks in the Airflow instance.
+The [KubernetesExecutor](https://airflow.apache.org/docs/apache-airflow/stable/executor/kubernetes.html) and the `KubernetesPodOperator` both dynamically launch and terminate pods to run Airflow tasks. As the names suggest, `KubernetesExecutor` is an executor, which means it affects how all tasks in an Airflow instance are executed, while the `KubernetesPodOperator` is an operator defining that a single task is to be launched in a Kubernetes pod with the given configuration and does not affect any other tasks in the Airflow instance.
 
-Compared to the KPO, the KubernetesExecutor:
+Compared to the KPO, the `KubernetesExecutor`:
 
-- Runs Airflow tasks in a Kubernetes pod without needing to build a Docker image.
+- Runs Airflow tasks in a Kubernetes pod without the user needing to specify a Docker image.
 - Is implemented at the configuration level of the Airflow instance, which means _all_ tasks will each be run in their own Kubernetes pod. This may be desired in some use cases to leverage auto-scaling, but is generally not ideal for environments with a high volume of shorter running tasks.
-- Has less abstraction over pod configuration. All task-level configurations have to be passed in as a dictionary via the `BaseOperator` argument `executor_config`.
-- creates a new field in the view of individual task instances in the Airflow UI `K8s Pod Spec` which shows the specifications of the Pod that was run.
-- If a custom Docker image is passed to the KubernetesExecutor, it needs to have Airflow installed, otherwise the task will not run. This is not the case with the KPO, which can run any valid Docker image.
+- Has less abstraction over pod configuration. All task-level configurations have to be passed in as a dictionary via the `BaseOperator` argument `executor_config`, which is available to all operators. Details on configuring the `KubernetesExecutor` can be found in the [Airflow documentation](https://airflow.apache.org/docs/apache-airflow/stable/executor/kubernetes.html).
+- If a custom Docker image is passed to the `KubernetesExecutor`, it needs to have Airflow installed, otherwise the task will not run. This is not the case with the KPO, which can run any valid Docker image.
 
-Both the KubernetesPodOperator and the KubernetesExecutor can use the entire Kubernetes API with regards to pod creation. Which one to use is an individual choice based on the user's requirements and preferences. You can think of the KPO as "Docker image first" and the KubernetesExecutor as "operator first" implementations. The KPO is generally ideal for controlling the environment the task is run in, while the KubernetesExecutor is ideal for controlling resource optimization.
+Both the `KubernetesPodOperator` and the `KubernetesExecutor` can use the entire Kubernetes API with regards to pod creation. Which one to use is an individual choice based on the user's requirements and preferences. You can think of the KPO as "Docker image first" and the `KubernetesExecutor` as "operator first" implementations. The KPO is generally ideal for controlling the environment the task is run in, while the `KubernetesExecutor` is ideal for controlling resource optimization. Frequently the KPO is used in an Airflow environment using the `KubernetesExecutor` to run some tasks where the focus is on environment control while the other tasks are run in pods via the `KubernetesExecutor`.
 
-## How to configure the KubernetesPodOperator
+## How to configure the `KubernetesPodOperator`
 
-The KPO launches any valid Docker Image provided to it (passed via the `image` parameter) in a new Kubernetes pod on an existing Kubernetes cluster. The operator has many other parameters which specify the pod configuration which the KPO translates into a call to the [Kubernetes API](https://kubernetes.io/docs/reference/kubernetes-api/). The KubernetesPodOperator offers full access to Kubernetes API functionality relating to pod creation.    
+The KPO launches any valid Docker Image provided to it (passed via the `image` parameter) in a new Kubernetes pod on an existing Kubernetes cluster. The operator has many other parameters which specify the pod configuration which the KPO translates into a call to the [Kubernetes API](https://kubernetes.io/docs/reference/kubernetes-api/). The `KubernetesPodOperator` offers full access to Kubernetes API functionality relating to pod creation.    
 
-The KubernetesPodOperator can be instantiated like any other operator within the context of a DAG. The following are some of the arguments that can be passed to the operator.
+The `KubernetesPodOperator` can be instantiated like any other operator within the context of a DAG. The following are some of the arguments that can be passed to the operator.
 
 **Mandatory arguments** are:
 
 - `task_id`: a unique string identifying the task within Airflow.
-- `namespace`: the namespace within your Kubernetes cluster the new Pod should be assigned to.
-- `name`: the name of the Pod created. This name needs to be unique for each Pod within a namespace.
+- `namespace`: the namespace within your Kubernetes cluster the new pod should be assigned to.
+- `name`: the name of the pod created. This name needs to be unique for each pod within a namespace.
 - `image`: a Docker image to launch. Images from [hub.docker.com](https://hub.docker.com/) can be passed in with just the image name, custom repositories have to be given as full URLs.
 
 Commonly used **optional arguments** include:
 
-- `random_name_suffix`: generates a random suffix for the Pod name if set to `True`. Avoids naming conflicts when running a large number of Pods.
-- `labels`: add key:value pairs to the Pod which can be used to logically group decoupled objects together.
-- `ports`: provides the possibility to override default ports for the Pod.
-- `reattach_on_restart`: defines how to handle losing the worker while the Pod is running, by default (`True`) the existing Pod will reattach to the worker on the next try. `False` creates a new Pod for each try.
-- `is_delete_operator_pod`: `True` by default, will delete the Pod when it reaches its final state or when the execution is interrupted.
+- `random_name_suffix`: generates a random suffix for the pod name if set to `True`. Avoids naming conflicts when running a large number of pods.
+- `labels`: add key:value pairs to the pod which can be used to logically group decoupled objects together.
+- `ports`: provides the possibility to override default ports for the pod.
+- `reattach_on_restart`: defines how to handle losing the worker while the pod is running, by default (`True`) the existing pod will reattach to the worker on the next try. `False` creates a new pod for each try.
+- `is_delete_operator_pod`: `True` by default, will delete the pod when it reaches its final state or when the execution is interrupted.
 - `get_logs`: provides the `stdout` of the container as task-logs to the Airflow logging system.
-- `log_events_on_failure`: if set to `True` events will be logged in case the Pod fails (default: `False`).
-
-There are also many other arguments that can be used to configure the pod and pass information to the Docker image. For example, the 'Spinning up a Pod in EKS from Airflow' section below shows how to define an entrypoint (`cmds`) and its arguments (`arguments`) for your container.
-
-> **Note**: The following KPO arguments can be used with Jinja templates: `image`, `cmds`, `arguments`, `env_vars`, `labels`, `config_file`, `Pod_template_file`, and `namespace`.
-
-To specify environment variables for a Pod it is possible to use the argument `env_vars` for individual variables or pass in a [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/) via `volumes`.
-
-Management of distributed resources and balancing of workloads are some of the core functionalities of Kubernetes. The [Kubernetes Scheduler](https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/) on the Kubernetes Control Plane matches each Pod to the best physical or virtual machine (called Node in Kubernetes) possible. When using the KPO there are multiple ways to add information configuring this process:
-
+- `log_events_on_failure`: if set to `True` events will be logged in case the pod fails (default: `False`).
+- `env_vars`: allows the user to specify individual environment variables for a pod.
 - `resources`: allows the user to pass a dictionary with resource requests (keys: `request_memory`, `request_cpu`) and limits (keys: `limit_memory`, `limit_cpu`, `limit_gpu`). See the [Kubernetes Documentation on Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for more information.
-- `node_selectors`, `affinity` and `tolerations` are ways to further specify rules for [Pod to node assignment](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-Pod-node/).
+- `volumes`: can be used to pass in a modified `k8s.V1Volume`, see also the [Kubernetes example DAG from the Airflow documentation](https://airflow.apache.org/docs/apache-airflow-providers-cncf-kubernetes/stable/_modules/tests/system/providers/cncf/kubernetes/example_kubernetes.html).
+- `affinity` and `tolerations` are ways to further specify rules for [pod to node assignment](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-Pod-node/). Like the `volumes` parameter they also require their input as a `k8s` object.
 
-To pass small amounts of information between tasks Airflow uses [XComs](https://airflow.apache.org/docs/apache-airflow/stable/concepts/xcoms.html). It is possible to push content from the container within a Pod, specifically from the file `/airflow/xcom/return.json`, by setting the KPO argument `do_xcom_push` to `True`. Please remember that the `return.json` file does not exist and `do_xcom_push` to `True` will cause a task to fail if the file has not been created by the user via the Docker image.
+There are also many other arguments that can be used to configure the pod and pass information to the Docker image. For example, the 'Spinning up a pod in EKS from Airflow' section below shows how to define an entrypoint (`cmds`) and its arguments (`arguments`) for your container.
 
-> **Note**: Many more arguments are available to customize the KubernetesPodOperator further. For a complete and up to date list see the [KubernetesPodOperator source code](https://github.com/apache/airflow/blob/main/airflow/providers/cncf/kubernetes/operators/kubernetes_Pod.py).
+> **Note**: The following KPO arguments can be used with Jinja templates: `image`, `cmds`, `arguments`, `env_vars`, `labels`, `config_file`, `pod_template_file`, and `namespace`.
+
+> **Note**: Many more arguments are available to customize the `KubernetesPodOperator` further. For a complete and up to date list see the [`KubernetesPodOperator` source code](https://github.com/apache/airflow/blob/main/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py).
 
 ### Configuring Kubernetes Connection
 
-The KubernetesPodOperator uses the [Kubernetes Hook](https://registry.astronomer.io/providers/kubernetes/modules/kuberneteshook) to connect to the [Kubernetes API](https://kubernetes.io/docs/reference/kubernetes-api/) of a Kubernetes cluster. The KPO has 4 parameters pertaining to the Kubernetes Connection:
+When leaving the `in_cluster` parameter on its default setting (`True`) it is not necessary to further configure the Kubernetes connection, the pod specified by the `KubernetesPodOperator` will be run on the same Kubernetes cluster as your Airflow instance is running on.
+
+If you are not running Airflow on Kubernetes or want to send the pod to a different cluster than the one currently hosting your Airflow instance the three arguments below will be necessary to specify how the KPO will use the [Kubernetes Hook](https://registry.astronomer.io/providers/kubernetes/modules/kuberneteshook) to connect to the [Kubernetes API](https://kubernetes.io/docs/reference/kubernetes-api/) of a different Kubernetes cluster.
 
 - `kubernetes_conn_id`: uses a [connection](https://www.astronomer.io/guides/connections) stored in the [Airflow metadata database](https://www.astronomer.io/guides/airflow-database), which can be configured in the Airflow UI under **Admin** -> **Connections**.
-- `in_cluster`: by default set to `True`, which means the new Pod will be spun up in the same cluster, you are running your Airflow instance in.
-- `config_file`: The path to the Kubernetes config file. If not specified, default value is `~/.kube/config`.
-- `cluster_context`: is used to specify a context that points to a Kubernetes cluster when `in_cluster` is set to `False`. This parameter is used to select a specific cluster if several are defined within your config file.
+- `config_file`: sets the path to the `KubeConfig` file. If not specified, the default value is `~/.kube/config`.
+- `cluster_context`: is used to select a specific cluster if several are defined within the `KubeConfig` file.
 
 The `kubernetes_conn_id` is the preferred way of setting up your Kubernetes connection. `in_cluster`, `cluster_context` and the path to the `config_file` can be set within your connection and overwritten by using the parameters in the KPO. Setting these parameters at the level of `airflow.cfg` has been deprecated.
 
 ### Example: Using the KPO to Run a Script in Another Language
 
-A frequent use case for the KubernetesPodOperator is to run scripts for tasks better described in a language other than Python. For this purpose a custom Docker image has to be built and either run from either a public or private [DockerHub repository](https://docs.docker.com/docker-hub/repos/).
+A frequent use case for the `KubernetesPodOperator` is to run scripts for tasks better described in a language other than Python. For this purpose a custom Docker image has to be built and either run from a public or private [DockerHub repository](https://docs.docker.com/docker-hub/repos/).
 
-> **Note**: Astro provides documentation on [how to run images from private repositories](https://docs.astronomer.io/astro/kubernetesPodoperator).
+> **Note**: Astro provides documentation on [how to run images from private repositories](https://docs.astronomer.io/astro/kubernetespodoperator).
 
 The code below shows a Haskell script which takes the environment variable `NAME_TO_GREET` and prints a message containing it to the console:
 
@@ -145,12 +142,12 @@ RUN cabal install
 CMD ["haskell_example"]
 ```
 
-After making the Docker image available it can be run from the KPO via the `image` argument. The example DAG below showcases a variety of arguments of the KubernetesPodOperator, including how to pass the environment variable `NAME_TO_GREET` which is used from within the Haskell code.
+After making the Docker image available it can be run from the KPO via the `image` argument. The example DAG below showcases a variety of arguments of the `KubernetesPodOperator`, including how to pass the environment variable `NAME_TO_GREET` which is used from within the Haskell code.
 
 ```python
 from airflow import DAG
 from datetime import datetime
-from airflow.providers.cncf.kubernetes.operators.kubernetes_Pod import (
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import (
                                                         KubernetesPodOperator)
 from airflow.configuration import conf
 
@@ -177,33 +174,33 @@ with DAG(
         # the Docker image to launch
         image='<image location>',
 
-        ## arguments pertaining to where the Pod is launched
-        # launch the Pod on the same cluster as Airflow is running on
+        ## arguments pertaining to where the pod is launched
+        # launch the pod on the same cluster as Airflow is running on
         in_cluster=True,
-        # launch the Pod in the same namespace as Airflow is running in
+        # launch the pod in the same namespace as Airflow is running in
         namespace=namespace,
 
-        ## Pod configuration
-        # name the Pod
-        name='my_Pod',
-        # give the Pod name a random suffix, ensure uniqueness in the namespace
+        ## pod configuration
+        # name the pod
+        name='my_pod',
+        # give the pod name a random suffix, ensure uniqueness in the namespace
         random_name_suffix=True,
-        # attach labels to the Pod, can be used for grouping
+        # attach labels to the pod, can be used for grouping
         labels={'app':'backend', 'env':'dev'},
-        # reattach to worker instead of creating a new Pod on worker failure
+        # reattach to worker instead of creating a new pod on worker failure
         reattach_on_restart=True,
-        # delete Pod after the task is finished
+        # delete pod after the task is finished
         is_delete_operator_pod=True,
         # get log stdout of the container as task logs
         get_logs=True,
-        # log events in case of Pod failure
+        # log events in case of pod failure
         log_events_on_failure=True,
         # pass your name as an environment var
         env_vars={"NAME_TO_GREET": f"{name}"}
         )
 ```
 
-## KubernetesPodOperator best practices
+## `KubernetesPodOperator` best practices
 
 SECTION INCOMPLETE
 
@@ -214,19 +211,20 @@ Suggestions from issues:
 Some advice on where to store the images such that they can be retrieved on Astro
 - how to best set env variables
 
-## Example: Using the KubernetesPodOperator with XComs
+## Example: Using the `KubernetesPodOperator` with XComs
 
 [XCom](https://airflow.apache.org/docs/apache-airflow/stable/concepts/xcoms.html) is a commonly used Airflow feature for passing small amounts of data between tasks. It is possible to use this feature with the KPO to both receive values stored in XCom and push values to XCom.
 
 The DAG below shows a straightforward ETL pipeline with an `extract_data` task that runs a query on a database and returns a value; the return value is automatically pushed to XComs thanks to the [TaskFlow API](https://airflow.apache.org/docs/apache-airflow/stable/tutorial_taskflow_api.html#tutorial-on-the-taskflow-api).  
 
-The `transform` task is a KubernetesPodOperator which requires the XCom data pushed from the upstream task before it, and launches an image having been built with the following Dockerfile:
+The `transform` task is a `KubernetesPodOperator` which requires the XCom data pushed from the upstream task before it, and launches an image having been built with the following Dockerfile:
 
 ```dockerfile
 FROM python
 
 WORKDIR /
 
+# creating the file to write XComs to
 RUN mkdir -p airflow/xcom         
 RUN echo "" > airflow/xcom/return.json
 
@@ -235,7 +233,7 @@ COPY multiply_by_23.py ./
 CMD ["python", "./multiply_by_23.py"]
 ```
 
-When using XComs with the KPO, it is very important to create the file `airflow/xcom/return.json`, because Airflow will only look for XComs to pull at that specific location. The image also contains a simple Python script to multiply an environment variable by 23, package the result into a json and write that json to the correct file to be retrieved as an XCom.
+When using XComs with the KPO, it is very important to create the file `airflow/xcom/return.json` in your Docker container (ideally from within your Dockerfile as seen above), because Airflow will only look for XComs to pull at that specific location. The image also contains a simple Python script to multiply an environment variable by 23, package the result into a json and write that json to the correct file to be retrieved as an XCom. The XComs from the KPO will only be pushed if the task itself was marked as successful.  
 
 ```python
 import os
@@ -262,7 +260,7 @@ Below you can find the full DAG code. Remember to only turn on `do_xcom_push` if
 ```python
 from airflow import DAG
 from datetime import datetime
-from airflow.providers.cncf.kubernetes.operators.kubernetes_Pod import KubernetesPodOperator
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
 from airflow.configuration import conf
 from airflow.decorators import task
 
@@ -281,6 +279,7 @@ with DAG(
 
     @task
     def extract_data():
+        # simulating querying from a database
         data_point = random.randint(0,100)
         return data_point
 
@@ -291,14 +290,14 @@ with DAG(
         # arguments pertaining to the image and commands executed
         image='< image location >', # the Docker Image to launch
 
-        # arguments pertaining to where the Pod is launched
-        in_cluster=True, # launch the Pod on the same cluster as Airflow is running on
-        namespace=namespace, # launch the Pod in the same namespace as Airflow is running in
+        # arguments pertaining to where the pod is launched
+        in_cluster=True, # launch the pod on the same cluster as Airflow is running on
+        namespace=namespace, # launch the pod in the same namespace as Airflow is running in
 
-        # Pod configuration
-        name='my_Pod', # naming the Pod
+        # pod configuration
+        name='my_pod', # naming the pod
         get_logs=True, # log stdout of the container as task logs
-        log_events_on_failure=True, #log events in case of Pod failure
+        log_events_on_failure=True, #log events in case of pod failure
         env_vars={"DATA_POINT": "{{ ti.xcom_pull(task_ids='extract_data', key='return_value') }}"},
         do_xcom_push=True #push the contents from xcom.json to xcoms
         )
@@ -321,7 +320,7 @@ The example below shows the steps to take to set up an EKS cluster on AWS and ru
 
 > **Note**: If you are using [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/) consider using [GKEStartPodOperator](https://registry.astronomer.io/providers/google/modules/gkestartPodoperator).
 
-> **Note**: In the example we are using the KubernetesPodOperator to connect to an EKS Cluster to demonstrate the general use case. The [EksPodOperator](https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/_api/airflow/providers/amazon/aws/operators/eks/index.html#module-airflow.providers.amazon.aws.operators.eks) is an operator directly derived form the KPO that could also be used for this specific use case.
+> **Note**: In the example we are using the `KubernetesPodOperator` to connect to an EKS Cluster to demonstrate the general use case. The [EksPodOperator](https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/_api/airflow/providers/amazon/aws/operators/eks/index.html#module-airflow.providers.amazon.aws.operators.eks) is an operator directly derived form the KPO that could also be used for this specific use case.
 
 ### Step 1: Set up an EKS cluster on AWS
 
@@ -454,11 +453,17 @@ In the Airflow UI navigate to **Admin** -> **Connections** to set up the connect
 
 ![Adding AWS connection](https://assets2.astronomer.io/main/guides/your-guide-folder/aws_connection.png)
 
-### Step 6: Create the DAG with the KPO 
+### Step 6: Create the DAG with the KPO
 
-If dynamic behavior of the EKS cluster is desired, e.g. Nodes get created with specifications for a task and deleted after the task has run, it is necessary to use several classes from the Amazon provider package as shown in the example DAG below. If your remote Kubernetes cluster has Nodes already available you will only need the KubernetesPodOperator itself (task number 3 in the example).
+If dynamic behavior of the EKS cluster is desired, e.g. Nodes get created with specifications for a task and deleted after the task has run, it is necessary to use several classes from the Amazon provider package as shown in the example DAG below. If your remote Kubernetes cluster has Nodes already available you will only need the `KubernetesPodOperator` itself (task number 3 in the example).
 
-The example DAG contains 5 consecutive tasks. The first one creates a Nodegroup according to the users' specifications and afterwards a sensor checks that the cluster is running correctly. The third tasks is the actual KubernetesPodOperator running any valid Docker image in a Pod on the newly created Nodegroup on the remote cluster. The example below uses the standard `Ubuntu` image to print "hello" to the console using a `bash` command. Lastly the Nodegroup gets deleted and the deletion gets verified.
+The example DAG contains 5 consecutive tasks:
+
+- Create a nodegroup according to the users' specifications.
+- Use a sensor to check that the cluster is running correctly.
+- Use the `KubernetesPodOperator` to run any valid Docker image in a pod on the newly created nodegroup on the remote cluster. The example DAG uses the standard `Ubuntu` image to print "hello" to the console using a `bash` command.
+- Delete the nodegroup.
+- Verify that the nodegroup has been deleted.
 
 > **Note**: The argument `labels={"kubernetes_pod_operator": "external-cluster"}` in the KPO of the example DAG is specific to behavior of the Astro Cloud and not needed for other implementations.
 
@@ -469,7 +474,7 @@ from datetime import datetime
 from airflow.configuration import conf
 
 # import the KPO
-from airflow.providers.cncf.kubernetes.operators.kubernetes_Pod import (
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import (
                                                         KubernetesPodOperator)
 
 # import EKS related packages from the Amazon Provider
@@ -543,12 +548,12 @@ with DAG(
         task_id="run_on_EKS",
         cluster_context='<arn of your cluster>',
         namespace="airflow-kpo-default",
-        name="example_Pod",
+        name="example_pod",
         image='ubuntu',
         cmds=['bash', '-cx'],
         arguments=["echo hello"],
         get_logs=True,
-        is_delete_operator_Pod=False,
+        is_delete_operator_pod=False,
         in_cluster=False,
         config_file='/usr/local/airflow/include/config',
         startup_timeout_seconds=240,

--- a/guides/kubepod-operator.md
+++ b/guides/kubepod-operator.md
@@ -9,7 +9,7 @@ tags: ["Kubernetes", "Operators"]
 
 ## Overview
 
-The [KubernetesPodOperator](https://registry.astronomer.io/providers/kubernetes/modules/kubernetesPodoperator) (KPO) is an operator from the Kubernetes provider package designed to provide a straightforward way to execute a task in a Kubernetes Pod from your Airflow environment. In a nutshell the KPO is an abstraction over a call to the Kubernetes API to launch a Pod.
+The [KubernetesPodOperator](https://registry.astronomer.io/providers/kubernetes/modules/kubernetesPodoperator) (KPO) is an operator from the Kubernetes provider package designed to provide a straightforward way to execute a task in a Kubernetes pod from your Airflow environment. In a nutshell, the KPO is an abstraction over a call to the Kubernetes API to launch a pod.
 
 In this guide, we list the requirements to run the KubernetesPodOperator, explain when to use it and cover its most important arguments, as well as the difference between the KPO and KubernetesExecutor. We also provide concrete examples on how to use the KPO to run a task in a language other than Python, how to use the KPO with XComs, and how to launch a pod in a remote AWS EKS Cluster.  
 
@@ -412,7 +412,7 @@ users:
 
 The `KubeConfig` file is how the KPO will connect to a Kubernetes cluster by running the `awscli` with the default profile, using the credentials you provided in Step 1.
 
-### Step 3 Add a namespace and service account to the EKS Cluster
+### Step 3: Add a namespace and service account to the EKS Cluster
 
 It is best practice to use a new namespace and separate service account for all pods sent to the EKS cluster from the Airflow environment.  
 

--- a/guides/kubepod-operator.md
+++ b/guides/kubepod-operator.md
@@ -13,9 +13,9 @@ The [`KubernetesPodOperator`](https://registry.astronomer.io/providers/kubernete
 
 In this guide, we list the requirements to run the `KubernetesPodOperator`, explain when to use it and cover its most important arguments, as well as the difference between the KPO and `KubernetesExecutor`. We also provide concrete examples on how to use the KPO to run a task in a language other than Python, how to use the KPO with XComs, and how to launch a Pod in a remote AWS EKS Cluster.  
 
-> **Note**: Kubernetes is a powerful tool for Container Orchestration with complex functionality. If you are unfamiliar with Kubernetes we recommend taking a look at the [Kubernetes 101 Guide](https://www.astronomer.io/guides/intro-to-kubernetes/) to get a general overview. For in-depth information check out the [Kubernetes Documentation](https://kubernetes.io/docs/home/).  
+> **Note**: Kubernetes is a powerful tool for Container Orchestration with complex functionality. If you are unfamiliar with Kubernetes we recommend taking a look at the [Kubernetes Documentation](https://kubernetes.io/docs/home/).  
 
-## Requirements For Using the `KubernetesPodOperator`
+## Requirements For Using the KubernetesPodOperator
 
 To use the `KubernetesPodOperator` it is necessary to install the Kubernetes provider package.
 
@@ -29,7 +29,7 @@ You will also need an existing Kubernetes cluster to connect to, which commonly 
 
 > **Note**: On Astro, the infrastructure needed to run KPO with CeleryExecutor is pre-built into every cluster. Astronomer provides [comprehensive documentation on using the KPO on Astro](https://docs.astronomer.io/astro/kubernetespodoperator).  
 
-### Running the `KubernetesPodOperator` Locally
+### Running the KubernetesPodOperator Locally
 
 When developing and testing changes it can be tedious to deploy to a remote environment, which is why many users set up their local dev environment to support usage of the KPO. This can be accomplished in several ways.
 
@@ -39,7 +39,7 @@ It is also possible to run open source Airflow within a local Kubernetes cluster
 
 When running Airflow within a Kubernetes cluster, using the KPO does not require further configuration beyond leaving the `KubernetesPodOperator` parameter `in_cluster` on its default setting (`True`) to run a new Pod within the same cluster. An example on how to run a Pod on a remote cluster, including in the case of not running local Airflow on Kubernetes, is presented at the end of this guide.
 
-## When to use the `KubernetesPodOperator`
+## When to use the KubernetesPodOperator
 
 The `KubernetesPodOperator` runs any Docker image provided to it, whether they are pulled from [DockerHub](https://hub.docker.com/) or from private repositories. Frequent use cases are:
 
@@ -53,7 +53,7 @@ Sometimes you may want to run Pods on different clusters, for example if only so
 
 > **Note**: A simple way to execute tasks in different clusters with different compute resources using worker queues is an upcoming feature on Astro!
 
-### `KubernetesPodOperator` vs `KubernetesExecutor`
+### KubernetesPodOperator vs KubernetesExecutor
 
 In Airflow you have the option to choose between a variety of [executors](https://www.astronomer.io/guides/airflow-executors-explained) which determine how your Airflow tasks will be executed.
 
@@ -103,15 +103,18 @@ There are also many other arguments that can be used to configure the Pod and pa
 
 ### Configuring Kubernetes Connection
 
-When leaving the `in_cluster` parameter on its default setting (`True`) it is not necessary to further configure the Kubernetes connection. The Pod specified by the `KubernetesPodOperator` will be run on the same Kubernetes cluster as your Airflow instance is running on.
+When leaving the `in_cluster` parameter on its default setting (`True`) it is not necessary to further configure the Kubernetes connection, beyond specifying the required parameter `namespace`. The Pod specified by the `KubernetesPodOperator` will be run on the same Kubernetes cluster as your Airflow instance is running on.
 
-If you are not running Airflow on Kubernetes or want to send the Pod to a different cluster than the one currently hosting your Airflow instance, the three arguments below will be necessary to specify how the KPO will use the [Kubernetes Hook](https://registry.astronomer.io/providers/kubernetes/modules/kuberneteshook) to connect to the [Kubernetes API](https://kubernetes.io/docs/reference/kubernetes-api/) of a different Kubernetes cluster.
+If you are not running Airflow on Kubernetes or want to send the Pod to a different cluster than the one currently hosting your Airflow instance, you can set up a Kubernetes Cluster [Connection](https://www.astronomer.io/guides/connections) in the Airflow UI under **Admin** -> **Connections**, which will use the [Kubernetes Hook](https://registry.astronomer.io/providers/kubernetes/modules/kuberneteshook) to connect to the [Kubernetes API](https://kubernetes.io/docs/reference/kubernetes-api/) of a different Kubernetes cluster. This connection can be passed to the `KubernetesPodOperator` via the `kubernetes_conn_id` argument and needs two components to work:
 
-- `kubernetes_conn_id`: uses a [connection](https://www.astronomer.io/guides/connections) stored in the [Airflow metadata database](https://www.astronomer.io/guides/airflow-database), which can be configured in the Airflow UI under **Admin** -> **Connections**.
-- `config_file`: sets the path to the `KubeConfig` file. If not specified, the default value is `~/.kube/config`.
-- `cluster_context`: is used to select a specific cluster if several are defined within the `KubeConfig` file.
+- a `KubeConfig` file, provided as either a path to the file or in JSON format.
+- the cluster context to select a specific cluster from the provided `KubeConfig` file.
 
-The `kubernetes_conn_id` is the preferred way of setting up your Kubernetes connection. `in_cluster`, `cluster_context` and the path to the `config_file` can be set within your connection and overwritten by using the parameters in the KPO. Setting these parameters at the level of `airflow.cfg` has been deprecated.
+The picture below shows how to set up a Kubernetes Cluster Connection in the Airflow UI.
+
+![Kubernetes Cluster Connection](https://assets2.astronomer.io/main/guides/kubepod-operator/kubernetes_cluster_connection.png)
+
+The components of the connection can also be set or overwritten at the task level by using the arguments `config_file` (to specify the path to the `KubeConfig` file) and `cluster_context`. Setting these parameters at the level of `airflow.cfg` has been deprecated.
 
 ### Example: Using the KPO to Run a Script in Another Language
 
@@ -200,18 +203,7 @@ with DAG(
         )
 ```
 
-## `KubernetesPodOperator` best practices
-
-SECTION INCOMPLETE
-
-Suggestions from issues:  
-
-- CI/CD guidelines (such as you need to be pushing updates to the KPO image)
-- make sure each KPO image update has a unique tag
-Some advice on where to store the images such that they can be retrieved on Astro
-- how to best set env variables
-
-## Example: Using the `KubernetesPodOperator` with XComs
+## Example: Using the KubernetesPodOperator with XComs
 
 [XCom](https://airflow.apache.org/docs/apache-airflow/stable/concepts/xcoms.html) is a commonly used Airflow feature for passing small amounts of data between tasks. It is possible to use this feature with the KPO to both receive values stored in XCom and push values to XCom.
 
@@ -318,9 +310,7 @@ However, you may want to use a specific AWS or GCP account that you keep separat
 
 The example below shows the steps to take to set up an EKS cluster on AWS and run a Pod on it from an Airflow instance where cross-account access is not feasible. After setup of the EKS cluster, the `KubeConfig` as well as the `AWS Profile` have to be provided to Airflow to make the connection to the remote cluster. Note that the same general steps are applicable to other Kubernetes services (e.g. GKE).  
 
-> **Note**: If you are using [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/) consider using [GKEStartPodOperator](https://registry.astronomer.io/providers/google/modules/gkestartPodoperator).
-
-> **Note**: In the example we are using the `KubernetesPodOperator` to connect to an EKS Cluster to demonstrate the general use case. The [EksPodOperator](https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/_api/airflow/providers/amazon/aws/operators/eks/index.html#module-airflow.providers.amazon.aws.operators.eks) is an operator directly derived form the KPO that could also be used for this specific use case.
+> **Note**: Some platforms which can host Kubernetes clusters have their own specialised operators available like the [GKEStartPodOperator](https://registry.astronomer.io/providers/google/modules/gkestartPodoperator) and the [EksPodOperator](https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/_api/airflow/providers/amazon/aws/operators/eks/index.html#module-airflow.providers.amazon.aws.operators.eks).
 
 ### Step 1: Set up an EKS cluster on AWS
 
@@ -413,16 +403,11 @@ The `KubeConfig` file is how the KPO will connect to a Kubernetes cluster by run
 
 ### Step 3: Add a namespace and service account to the EKS Cluster
 
-It is best practice to use a new namespace and separate service account for all Pods sent to the EKS cluster from the Airflow environment.  
+It is best practice to use a new namespace for all Pods sent to the EKS cluster from the Airflow environment.  
 
 ```bash
 # create a new namespace on the EKS cluster
 kubectl create namespace <your namespace name>
-
-# if you are using a service account other than default in the Kubernetes
-# environment your Airflow instance is running it you will have to add a
-# service account of the same name to your remote cluster
-kubectl create serviceaccount <service account name> -n <your namespace name>
 ```
 
 ### Step 4: Adjust the Airflow configuration files
@@ -449,23 +434,21 @@ apache-airflow-providers-amazon
 
 ### Step 5: Add AWS connection ID
 
-In the Airflow UI navigate to **Admin** -> **Connections** to set up the connection to the AWS account running the target EKS cluster. Chose a unique connection ID and use your `aws_access_key_id` as login and your `aws_secret_access_key` as password.
-
-![Adding AWS connection](https://assets2.astronomer.io/main/guides/kubepod-operator/aws_connection.png)
+In the Airflow UI navigate to **Admin** -> **Connections** to set up the connection to the AWS account running the target EKS cluster. Chose a unique connection ID, the Connection Type 'Amazon Web Services' and use your `aws_access_key_id` as login and your `aws_secret_access_key` as password.
 
 ### Step 6: Create the DAG with the KPO
+
+> **Note**: When creating new deployments, users of the Astro cloud will need to set one additional argument in the KPO: `labels={"airflow_kpo_in_cluster": "False"}` to connect to a remote cluster. If you are trying to set up the KPO connecting to a remote cluster in an existing deployment please contact Customer Support.
 
 If dynamic behavior of the EKS cluster is desired, e.g. Nodes get created with specifications for a task and deleted after the task has run, it is necessary to use several classes from the Amazon provider package as shown in the example DAG below. If your remote Kubernetes cluster has Nodes already available you will only need the `KubernetesPodOperator` itself (task number 3 in the example).
 
 The example DAG contains 5 consecutive tasks:
 
-- Create a node group according to the users' specifications.
+- Create a node group according to the users' specifications (in the example using GPU resources).
 - Use a sensor to check that the cluster is running correctly.
 - Use the `KubernetesPodOperator` to run any valid Docker image in a Pod on the newly created node group on the remote cluster. The example DAG uses the standard `Ubuntu` image to print "hello" to the console using a `bash` command.
 - Delete the node group.
 - Verify that the node group has been deleted.
-
-> **Note**: The argument `labels={"kubernetes_pod_operator": "external-cluster"}` in the KPO of the example DAG is specific to behavior of the Astro Cloud and not needed for other implementations.
 
 ```python
 # import DAG object and utility packages
@@ -544,6 +527,9 @@ with DAG(
     )
 
     # task 3 the KPO running a task
+    # here, cluster_context and the config_file are defined at the task level
+    # it is of course also possible to abstract these values
+    # in a Kubernetes Cluster Connection
     run_on_EKS=KubernetesPodOperator(
         task_id="run_on_EKS",
         cluster_context='<arn of your cluster>',
@@ -557,8 +543,6 @@ with DAG(
         in_cluster=False,
         config_file='/usr/local/airflow/include/config',
         startup_timeout_seconds=240,
-        # this line is specific to users of Astro and not needed in OSS Airflow
-        labels={"kubernetes_pod_operator": "external-cluster"}
     )
 
     # task 4 deleting the node group

--- a/guides/kubepod-operator.md
+++ b/guides/kubepod-operator.md
@@ -2,20 +2,18 @@
 title: "KubernetesPodOperator on Astronomer"
 description: "Use the KubernetesPodOperator on Astronomer"
 date: 2018-07-17T00:00:00.000Z
-slug: "kubepod-operator"
+slug: "kubePod-operator"
 heroImagePath: null
 tags: ["Kubernetes", "Operators"]
 ---
 
 ## Overview
 
-The [KubernetesPodOperator](https://registry.astronomer.io/providers/kubernetes/modules/kubernetespodoperator) (KPO) is an operator from the Kubernetes provider package designed to provide a straightforward way to execute a task in a Kubernetes Pod from your Airflow environment. In a nutshell the KPO is an abstraction over a call to the Kubernetes API to launch a pod.
+The [KubernetesPodOperator](https://registry.astronomer.io/providers/kubernetes/modules/kubernetesPodoperator) (KPO) is an operator from the Kubernetes provider package designed to provide a straightforward way to execute a task in a Kubernetes Pod from your Airflow environment. In a nutshell the KPO is an abstraction over a call to the Kubernetes API to launch a Pod.
 
-In this guide we will list the requirements to run the KubernetesPodOperator, explain when to use it and cover its most important arguments, as well as the difference between the KPO and KubernetesExecutor. At the end of the guide we will provide two step-by-step examples on how to launch a pod within the same and within a different cluster.
+In this guide we will list the requirements to run the KubernetesPodOperator, explain when to use it and cover its most important arguments, as well as the difference between the KPO and KubernetesExecutor. We will also provide concrete examples on how to use the KPO to run a task in a language other than Python, how to use the KPO with XComs and how to launch a Pod in a remote AWS EKS Cluster.  
 
 > **Note**: Kubernetes is a powerful tool for Container Orchestration with complex functionality. If you are unfamiliar with Kubernetes we recommend taking a look at the [Kubernetes 101 Guide](https://www.astronomer.io/guides/intro-to-kubernetes/) to get a general overview. For in-depth information check out the [Kubernetes Documentation](https://kubernetes.io/docs/home/).  
-
-> **Note**: If you are using [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/) consider using [GKEStartPodOperator](https://registry.astronomer.io/providers/google/modules/gkestartpodoperator).
 
 ## Requirements to use the KubernetesPodOperator
 
@@ -29,93 +27,98 @@ Required versions of the `apache-airflow`, `cryptography` and `kubernetes` packa
 
 You will also need an existing Kubernetes cluster to connect to. It is _not_ necessary to use the Kubernetes Executor in order to use the KPO. You may use any of the following executors: `CeleryExecutor`, `KubernetesExecutor`, [`CeleryKubernetesExecutor`](https://airflow.apache.org/docs/apache-airflow/2.0.0/executor/celery_kubernetes.html). When using Celery remember to install its [provider](https://registry.astronomer.io/providers/celery).
 
-> **Note**: On Astro the infrastructure needed to run KPO with CeleryExecutor is pre-built into every Cluster. Astronomer provides [comprehensive documentation on using KPO on Astro](https://docs.astronomer.io/astro/kubernetespodoperator).  
+> **Note**: On Astro the infrastructure needed to run KPO with CeleryExecutor is pre-built into every Cluster. Astronomer provides [comprehensive documentation on using the KPO on Astro](https://docs.astronomer.io/astro/kubernetesPodoperator).  
 
-### KubernetesPodOperator in local development
+### The KubernetesPodOperator in local development
 
-There are several ways in which the KubernetesPodOperator can be run in local development. For users of the Astro CLI there is a [step-by-step tutorial](https://docs.astronomer.io/software/kubepodoperator-local) available in the Astro Documentation, which can also be adapted for other dockerized Airflow setups.
+There are several ways in which the KubernetesPodOperator can be run in local development. For users of the Astro CLI there is a [step-by-step tutorial](https://docs.astronomer.io/software/kubePodoperator-local) available in the Astro Documentation, which can also be adapted for other dockerized Airflow setups.
 
 It is also possible to run Open Source Airflow within a local Kubernetes Cluster using the [Helm Chart for Apache Airflow](https://airflow.apache.org/docs/helm-chart/stable/index.html). For a walkthrough of this setup you can refer to the recording of the [Getting Started With the Official Airflow Helm Chart Webinar](https://www.youtube.com/watch?v=39k2Sz9jZ2c&ab_channel=Astronomer).
 
-When running Airflow in a Kubernetes cluster using the KPO operator does not require further configuration beyond leaving the setting `in_cluster` on `True` to run a new pod within the same cluster.
+When running Airflow within a Kubernetes cluster using the KPO does not require further configuration beyond leaving the setting `in_cluster` on `True` to run a new Pod within the same cluster. An example on how to run a Pod on a remote cluster, including in the case of not running local Airflow on Kubernetes, is presented at the end of this guide.
 
 ## When to use the KubernetesPodOperator
 
 The KubernetesPodOperator runs any Docker image provided to it, whether they are pulled from [DockerHub](https://hub.docker.com/) or from private repositories. Frequent use cases are:
 
-- Running a task better described in a language other than Python.
+- Running a task better described in a language other than Python. For an example see the section 'Example: Using the KubernetesPodOperator to run a script in Haskell' below.
 - Having full control over how much compute resources and memory a single task can use.
 - Executing tasks in an separate environment with individual packages and dependencies.
+- Running tasks that necessitate using a version of Python not supported by your Airflow environment.
+- Running tasks with specific Node (a virtual or physical machine in Kubernetes) constrains such as only running on Nodes located in the European Union.
 
-Sometimes you may want to run pods on different clusters, for example if only some need GPU resources while others do not. This is also possible with the KPO and a step-by-step example is provided at the end of this guide.
+Sometimes you may want to run Pods on different clusters, for example if only some need GPU resources while others do not. This is also possible with the KPO and a step-by-step example is provided at the end of this guide.
+
+> **Note**: A simple way to execute tasks in different clusters with different compute resources using worker queues is an upcoming feature on Astro!
 
 ### KubernetesPodOperator vs KubernetesExecutor
 
-SECTION INCOMPLETE
-
 In Airflow you have the option to choose between a variety of [executors](https://www.astronomer.io/guides/airflow-executors-explained) which determine how your Airflow tasks will be executed.
 
-The [KubernetesExecutor](https://airflow.apache.org/docs/apache-airflow/stable/executor/kubernetes.html) and the KubernetesPodOperator both dynamically launch and terminate Pods to run Airflow tasks in. As the names suggest, KubernetesExecutor is an executor, which means it affects how all tasks in an Airflow instance are executed while the KubernetesPodOperator is an operator defining that a single task is to be launched in a Kubernetes pod with the given configuration, which does not affect any other tasks in the Airflow instance.
+The [KubernetesExecutor](https://airflow.apache.org/docs/apache-airflow/stable/executor/kubernetes.html) and the KubernetesPodOperator both dynamically launch and terminate Pods to run Airflow tasks in. As the names suggest, KubernetesExecutor is an executor, which means it affects how all tasks in an Airflow instance are executed while the KubernetesPodOperator is an operator defining that a single task is to be launched in a Kubernetes Pod with the given configuration, which does not affect any other tasks in the Airflow instance.
 
 Compared to the KPO the KubernetesExecutor:
 
-- is set at the configuration level of the Airflow instance, which means _all_ tasks will each be run in their own Kubernetes pod.
-- has less abstraction over pod configuration. All configurations have to be passed in as a dictionary via the argument `executor_config`.
-- creates a new field in the view of individual task instances in the Airflow UI `K8s Pod Spec` which shows the specifications of the pod that was run.
-- can only use Docker images that have Airflow installed, otherwise they will not be able to run the task. This is not the case with the KPO, which can run any valid Docker image.
+- can run all existing Airflow tasks in a Kubernetes Pod without needing to build a Docker image.
+- is set at the configuration level of the Airflow instance, which means _all_ tasks will each be run in their own Kubernetes Pod, which may be desired in some use cases to leverage auto-scaling but not ideal if many small tasks are run that would not need their own Pod to be started.
+- has less abstraction over Pod configuration. All configurations have to be passed in as a dictionary via the argument `executor_config`.
+- creates a new field in the view of individual task instances in the Airflow UI `K8s Pod Spec` which shows the specifications of the Pod that was run.
+- if a custom Docker image is passed to the KubernetesExecutor it needs to have Airflow installed, otherwise the task will not run. This is not the case with the KPO, which can run any valid Docker image.
+
+Both the KubernetesPodOperator and the KubernetesExecutor can use the entire Kubernetes API with regards to Pod creation, which means every task can be fulfilled with either option and which one to use is an individual choice based on the user's requirements and preferences. You can think of the KPO as "Docker Image first" and the KubernetesExecutor as "Operator first" implementations.
 
 ## How to configure the KubernetesPodOperator
 
-In this section we will list some of the parameters of the KubernetesPodOperator, for concrete use cases see section 'When to use the KPO' earlier in this guide. The KPO launches any valid Docker Image provided to it (`image`) in a new Kubernetes Pod on an existing Kubernetes cluster. The many other parameters available to the user are all specifications of the pod configuration which the KPO translates into a call to the [Kubernetes API](https://kubernetes.io/docs/reference/kubernetes-api/). The KubernetesPodOperator offers full access to KubernetesAPI functionality relating to pod creation.    
+In this section we will list some of the parameters of the KubernetesPodOperator, for concrete use cases see the section 'When to use the KPO' earlier in this guide. The KPO launches any valid Docker Image provided to it (`image`) in a new Kubernetes Pod on an existing Kubernetes cluster. The many other parameters available to the user are all specifications of the Pod configuration which the KPO translates into a call to the [Kubernetes API](https://kubernetes.io/docs/reference/kubernetes-api/). The KubernetesPodOperator offers full access to Kubernetes API functionality relating to Pod creation.    
 
-The KubernetesPodOperator can be instantiated like any other Operator within the context of a DAG. It can run with only a few arguments being mandatory. In fact the KPO will run a new pod in the same cluster with only the following arguments supplied:
+The KubernetesPodOperator can be instantiated like any other Operator within the context of a DAG. It can run with only a few arguments being mandatory. In fact the KPO will run a new Pod in the same cluster with only the following arguments supplied:
 
 - `task_id`: a unique string identifying the task within Airflow.
-- `namespace`: the namespace within your Kubernetes cluster the new pod should be assigned to.
-- `name`: the name of the pod created. This name needs to be unique for each pod within a namespace.
+- `namespace`: the namespace within your Kubernetes cluster the new Pod should be assigned to.
+- `name`: the name of the Pod created. This name needs to be unique for each Pod within a namespace.
 - `image`: a Docker image to launch. Images from [hub.docker.com](https://hub.docker.com/) can be passed in with just the image name, custom repositories have to be given as full URLs.
 
-Of course the pod created can be configured further, some of the most commonly used arguments are:
+Of course the Pod created can be configured further, some of the most commonly used arguments are:
 
-- `random_name_suffix`: generates a random suffix for the pod name if set to `True`. Avoids naming conflicts when running a large number of pods.
-- `labels`: add key:value pairs to the pod which can be used to logically group decoupled objects together.
-- `ports`: provides the possibility to override default ports for the pod.
-- `reattach_on_restart`: defines how to handle losing the worker while the pod is running, by default (`True`) the existing pod will reattach to the worker on the next try. `False` creates a new pod for each try.
-- `is_delete_operator_pod`: `True` by default, will delete the pod when it reaches its final state or when the execution is interrupted.
+- `random_name_suffix`: generates a random suffix for the Pod name if set to `True`. Avoids naming conflicts when running a large number of Pods.
+- `labels`: add key:value pairs to the Pod which can be used to logically group decoupled objects together.
+- `ports`: provides the possibility to override default ports for the Pod.
+- `reattach_on_restart`: defines how to handle losing the worker while the Pod is running, by default (`True`) the existing Pod will reattach to the worker on the next try. `False` creates a new Pod for each try.
+- `is_delete_operator_pod`: `True` by default, will delete the Pod when it reaches its final state or when the execution is interrupted.
 - `get_logs`: provides the `stdout` of the container as task-logs to the Airflow logging system.
-- `log_events_on_failure`: if set to `True` events will be logged in case the pod fails (default: `False`).
+- `log_events_on_failure`: if set to `True` events will be logged in case the Pod fails (default: `False`).
 
-As shown in 'Example: Spin up a pod in the same cluster' below, you can define an entrypoint (`cmds`) and its arguments (`arguments`) for your container, these two fields can be used with Jinja templates.
+As shown in 'Example: Spinning up a Pod in EKS from Airflow' below, you can define an entrypoint (`cmds`) and its arguments (`arguments`) for your container, these two fields can be used with Jinja templates.
 
-> **Note**: The following KPO arguments can be used with Jinja templates: image, cmds, arguments, env_vars, labels, config_file, pod_template_file and namespace.
+> **Note**: The following KPO arguments can be used with Jinja templates: image, cmds, arguments, env_vars, labels, config_file, Pod_template_file and namespace.
 
-To specify environment variables for a pod it is possible to use the argument `env_vars` for individual variables or pass in a [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/) via `volumes`.
+To specify environment variables for a Pod it is possible to use the argument `env_vars` for individual variables or pass in a [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/) via `volumes`.
 
-Management of distributed resources and balancing of workloads are some of the core functionalities of Kubernetes. The [Kubernetes Scheduler](https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/) on the Kubernetes Control Plane matches each pod to the best physical or virtual machine (called Node in Kubernetes) possible. When using the KPO there are multiple ways to add information configuring this process:
+Management of distributed resources and balancing of workloads are some of the core functionalities of Kubernetes. The [Kubernetes Scheduler](https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/) on the Kubernetes Control Plane matches each Pod to the best physical or virtual machine (called Node in Kubernetes) possible. When using the KPO there are multiple ways to add information configuring this process:
 
 - `resources`: allows the user to pass a dictionary with resource requests (keys: `request_memory`, `request_cpu`) and limits (keys: `limit_memory`, `limit_cpu`, `limit_gpu`). See the [Kubernetes Documentation on Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for more information.
-- `node_selectors`, `affinity` and `tolerations` are ways to further specify rules for [pod to node assignment](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/).
+- `node_selectors`, `affinity` and `tolerations` are ways to further specify rules for [Pod to node assignment](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-Pod-node/).
 
-To pass small amounts of information between tasks Airflow uses [XComs](https://airflow.apache.org/docs/apache-airflow/stable/concepts/xcoms.html). It is possible to push content from the container within a pod, specifically from the file `/airflow/xcom/return.json`, by setting the KPO argument `do_xcom_push` to `True`. Please remember that the `return.json` file does not exist and `do_xcom_push` to `True` will cause a task to fail if the file has not been created by the user via the Docker image.
+To pass small amounts of information between tasks Airflow uses [XComs](https://airflow.apache.org/docs/apache-airflow/stable/concepts/xcoms.html). It is possible to push content from the container within a Pod, specifically from the file `/airflow/xcom/return.json`, by setting the KPO argument `do_xcom_push` to `True`. Please remember that the `return.json` file does not exist and `do_xcom_push` to `True` will cause a task to fail if the file has not been created by the user via the Docker image.
 
-> **Note**: Many more arguments are available to customize the KubernetesPodOperator further. For a complete and up to date list see the [KubernetesPodOperator source code](https://github.com/apache/airflow/blob/main/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py).
+> **Note**: Many more arguments are available to customize the KubernetesPodOperator further. For a complete and up to date list see the [KubernetesPodOperator source code](https://github.com/apache/airflow/blob/main/airflow/providers/cncf/kubernetes/operators/kubernetes_Pod.py).
 
 ### Configuring Kubernetes Connection
 
 The KubernetesPodOperator uses the [Kubernetes Hook](https://registry.astronomer.io/providers/kubernetes/modules/kuberneteshook) to connect to the [Kubernetes API](https://kubernetes.io/docs/reference/kubernetes-api/) of a Kubernetes cluster. The KPO has 4 parameters pertaining to the Kubernetes Connection:
 
 - `kubernetes_conn_id`: uses a [connection](https://www.astronomer.io/guides/connections) stored in the [Airflow metadata database](https://www.astronomer.io/guides/airflow-database), which can be configured in the Airflow UI under **Admin** -> **Connections**.
-- `in_cluster`: by default set to `True`, which means the new pod will be spun up in the same cluster, you are running your Airflow instance in.
+- `in_cluster`: by default set to `True`, which means the new Pod will be spun up in the same cluster, you are running your Airflow instance in.
 - `config_file`: The path to the Kubernetes config file. If not specified, default value is `~/.kube/config`.
 - `cluster_context`: is used to specify a context that points to a Kubernetes cluster when `in_cluster` is set to `False`. This parameter is used to select a specific cluster if several are defined within your config file.
 
 The `kubernetes_conn_id` is the preferred way of setting up your Kubernetes connection. `in_cluster`, `cluster_context` and the path to the `config_file` can be set within your connection and overwritten by using the parameters in the KPO. Setting these parameters at the level of `airflow.cfg` has been deprecated.
 
-### Example: Using KubernetesPodOperator to run a script in Haskell
+### Example: Using the KubernetesPodOperator to run a script in Haskell
 
-A frequent use case for the KubernetesPodOperator is to run scripts in languages other than Python. For this purpose a custom Docker Image has to be build and either run a public or private [DockerHub repository](https://docs.docker.com/docker-hub/repos/).
+A frequent use case for the KubernetesPodOperator is to run scripts for tasks better described in a language other than Python. For this purpose a custom Docker image has to be build and either run from either a public or private [DockerHub repository](https://docs.docker.com/docker-hub/repos/).
 
-> **Note**: Astro provides documentation on [how to run images from private repositories](https://docs.astronomer.io/astro/kubernetespodoperator).
+> **Note**: Astro provides documentation on [how to run images from private repositories](https://docs.astronomer.io/astro/kubernetesPodoperator).
 
 The code below shows a Haskell script which takes the environment variable `NAME_TO_GREET` and prints a message containing it to the console:
 
@@ -127,7 +130,7 @@ main = do
         putStrLn ("Hello, " ++ name)
 ```
 
-The Dockerfile uses `cabal` as a system for building and packaging Haskell programs, for this example the `haskell_example.cabal` file built automatically when running `cabal init` in a directory name `haskell_example` is sufficient.
+The Dockerfile uses `cabal` as a system for building and packaging Haskell programs, for this example the `haskell_example.cabal` file built automatically when running `cabal init` in a directory named `haskell_example` is sufficient.
 
 ```Dockerfile
 FROM haskell
@@ -140,20 +143,22 @@ RUN cabal install
 CMD ["haskell_example"]
 ```
 
-After making the Docker image available it is possible to pull it into the KPO via the `image` argument. The example DAG below showcases a variety of arguments of the KubernetesPodOperator including how to pass the an environment variable `NAME_TO_GREET` which can be used from within the Haskell code.
+After making the Docker image available it is possible to launch it from the KPO via the `image` argument. The example DAG below showcases a variety of arguments of the KubernetesPodOperator including how to pass the environment variable `NAME_TO_GREET` which is used from within the Haskell code.
 
 ```python
 from airflow import DAG
 from datetime import datetime
-from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
+from airflow.providers.cncf.kubernetes.operators.kubernetes_Pod import (
+                                                        KubernetesPodOperator)
 from airflow.configuration import conf
 
 ## get the current Kubernetes namespace Airflow is running in
 namespace = conf.get("kubernetes", "NAMESPACE")
 
+## set the name that will be printed
 name = 'your_name'
 
-## instatiate the DAG
+## instantiate the DAG
 with DAG(
     start_date=datetime(2022,6,1),
     catchup=False,
@@ -167,31 +172,31 @@ with DAG(
         task_id='say_hello_name_in_haskell',
 
         ## arguments pertaining to the image and commands executed
-        # the Docker Image to launch
+        # the Docker image to launch
         image='<image location>',
 
-        ## arguments pertaining to where the pod is launched
-        # launch the pod on the same cluster as Airflow is running on
+        ## arguments pertaining to where the Pod is launched
+        # launch the Pod on the same cluster as Airflow is running on
         in_cluster=True,
-        # launch the pod in the same namespace as Airflow is running in
+        # launch the Pod in the same namespace as Airflow is running in
         namespace=namespace,
 
-        ## pod configuration
-        # name the pod
-        name='my_pod',
-        # give the pod name a random suffix, ensure uniqueness in the namespace
+        ## Pod configuration
+        # name the Pod
+        name='my_Pod',
+        # give the Pod name a random suffix, ensure uniqueness in the namespace
         random_name_suffix=True,
-        # attach labels to the pod, can be used for grouping
+        # attach labels to the Pod, can be used for grouping
         labels={'app':'backend', 'env':'dev'},
-        # reattach to worker instead of creating a new pod on worker failure
+        # reattach to worker instead of creating a new Pod on worker failure
         reattach_on_restart=True,
-        # delete pod after the task is finished
+        # delete Pod after the task is finished
         is_delete_operator_pod=True,
-        # log stdout of the container as task logs
+        # get log stdout of the container as task logs
         get_logs=True,
-        #log events in case of pod failure
+        # log events in case of Pod failure
         log_events_on_failure=True,
-        # passes your name as an environment var
+        # pass your name as an environment var
         env_vars={"NAME_TO_GREET": f"{name}"}
         )
 ```
@@ -209,9 +214,9 @@ Some advice on where to store the images such that they can be retrieved on Astr
 
 ## Example: Using the KubernetesPodOperator with XComs
 
-[XComs](https://airflow.apache.org/docs/apache-airflow/stable/concepts/xcoms.html) is a commonly used way to pass small amounts of data between tasks. It is possible to use this feature with the KPO both for it to receive values stored in XCom and push to XComs itself.
+[XComs](https://airflow.apache.org/docs/apache-airflow/stable/concepts/xcoms.html) is a commonly used way to pass small amounts of data between tasks. It is possible to use this feature with the KPO both for it to receive values stored in XCom and push values to XComs itself.
 
-The DAG below shows a straightforward ETL pipeline with an `extract_data` task simulating for example running a query on a database and returning one value that by being returned from the Python function is automatically pushed to XComs thanks to the [TaskFlow API](https://airflow.apache.org/docs/apache-airflow/stable/tutorial_taskflow_api.html#tutorial-on-the-taskflow-api).  
+The DAG below shows a straightforward ETL pipeline with an `extract_data` task simulating running a query on a database and returning one value that by being returned from the Python function is automatically pushed to XComs thanks to the [TaskFlow API](https://airflow.apache.org/docs/apache-airflow/stable/tutorial_taskflow_api.html#tutorial-on-the-taskflow-api).  
 
 The `transform` task is a KubernetesPodOperator which launches an image having been built with the following Dockerfile:
 
@@ -228,7 +233,7 @@ COPY multiply_by_23.py ./
 CMD ["python", "./multiply_by_23.py"]
 ```
 
-It is especially important to make sure to create the file `airflow/xcom/return.json` because Airflow will look for XComs to pull only there. The image also contains a simple Python script to multiply an environment variable by 23, package it in a json and write that json to the correct file.
+It is very important to make sure to create the file `airflow/xcom/return.json` because Airflow will only look for XComs to pull at that specific location. The image also contains a simple Python script to multiply an environment variable by 23, package the result into a json and write that json to the correct file to be retrieved as an XCom.
 
 ```python
 import os
@@ -249,11 +254,13 @@ f.close()
 
 Lastly the `load_data` task pulls the XCom returned from the `transform` task and prints it to the console.
 
+Below you can find the full DAG code. Remember to only turn on `do_xcom_push` if you have created the `airflow/xcom/return.json` within the Docker container run by the KPO, otherwise the task will fail.
+
 
 ```python
 from airflow import DAG
 from datetime import datetime
-from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
+from airflow.providers.cncf.kubernetes.operators.kubernetes_Pod import KubernetesPodOperator
 from airflow.configuration import conf
 from airflow.decorators import task
 
@@ -282,14 +289,14 @@ with DAG(
         # arguments pertaining to the image and commands executed
         image='< image location >', # the Docker Image to launch
 
-        # arguments pertaining to where the pod is launched
-        in_cluster=True, # launch the pod on the same cluster as Airflow is running on
-        namespace=namespace, # launch the pod in the same namespace as Airflow is running in
+        # arguments pertaining to where the Pod is launched
+        in_cluster=True, # launch the Pod on the same cluster as Airflow is running on
+        namespace=namespace, # launch the Pod in the same namespace as Airflow is running in
 
-        # pod configuration
-        name='my_pod', # naming the pod
+        # Pod configuration
+        name='my_Pod', # naming the Pod
         get_logs=True, # log stdout of the container as task logs
-        log_events_on_failure=True, #log events in case of pod failure
+        log_events_on_failure=True, #log events in case of Pod failure
         env_vars={"DATA_POINT": "{{ ti.xcom_pull(task_ids='extract_data', key='return_value') }}"},
         do_xcom_push=True #push the contents from xcom.json to xcoms
         )
@@ -302,13 +309,15 @@ with DAG(
     extract_data() >> transform >> load_data()
 ```
 
-## Example: Spinning up a pod in EKS from Airflow
-
-SECTION INCOMPLETE
+## Example: Spinning up a Pod in EKS from Airflow
 
 If some of your tasks require specific resources like a GPU you may want to run them in a different cluster than your Airflow Instance. In setups where both clusters are used by the same AWS or GCP account this can be managed with roles and permissions. There is also the possibility to use a CI account and enable [cross-account access to AWS EKS cluster resources](https://aws.amazon.com/blogs/containers/enabling-cross-account-access-to-amazon-eks-cluster-resources/).  
 
-The example below shows the steps to take to set up an EKS cluster on AWS and run a pod on it from an Airflow instance if cross-account access is not feasible. After setup of the EKS cluster the `KubeConfig` as well as the `AWS Profile` have to be provided to Airflow to make the connection to the remote cluster.  
+The example below shows the steps to take to set up an EKS cluster on AWS and run a Pod on it from an Airflow instance if cross-account access is not feasible. After setup of the EKS cluster the `KubeConfig` as well as the `AWS Profile` have to be provided to Airflow to make the connection to the remote cluster.  
+
+> **Note**: If you are using [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/) consider using [GKEStartPodOperator](https://registry.astronomer.io/providers/google/modules/gkestartPodoperator).
+
+> **Note**: In the example we are using the KubernetesPodOperator to connect to an EKS Cluster to demonstrate the general use case. The [EksPodOperator](https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/_api/airflow/providers/amazon/aws/operators/eks/index.html#module-airflow.providers.amazon.aws.operators.eks) is an operator directly derived form the KPO that can be used in this specific use case.
 
 ### Step 1: Set up an EKS cluster on AWS
 
@@ -367,35 +376,39 @@ The command above will copy information into your existing `KubeConfig` file at 
 apiVersion: v1
 clusters:
 - cluster:
-    certificate-authority-data: <key>
-    server: <address of your EKS server>
-  name: <arn of your EKS server>
+    certificate-authority-data: < certificate >
+    server: https://237894071AC2BE7FA91A58A6BF02570F.gr7.eu-central-1.eks.amazonaws.com
+  name: arn:aws:eks:eu-central-1:897696225347:cluster/example-cluster-airflow-2
 contexts:
 - context:
-    cluster: <arn of your EKS server>
-    user: <arn of your EKS server>
-  name: <arn of your EKS server>
-current-context: <arn of your EKS server>
+    cluster: <arn of your cluster>
+    user: <arn of your cluster>
+  name: <arn of your cluster>
+current-context: <arn of your cluster>
 kind: Config
 preferences: {}
 users:
-- name: <arn of your EKS server>
+- name: <arn of your cluster>
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1beta1
+      apiVersion: client.authentication.k8s.io/v1alpha1
       args:
       - --region
-      - < your region>
+      - <your cluster's AWS region>
       - eks
       - get-token
       - --cluster-name
-      - < your cluster name>
+      - <name of your cluster>
+      - --profile
+      - default
       command: aws
+      interactiveMode: IfAvailable
+      provideClusterInfo: false
 ```
 
 ### Step 3 Add a namespace and service account to the EKS Cluster
 
-It is best practice to use a new namespace for all pods sent to the EKS cluster from the Airflow environment and a separate service account.  
+It is best practice to use a new namespace for all Pods sent to the EKS cluster from the Airflow environment and a separate service account.  
 
 ```bash
 # create a new namespace on the EKS cluster
@@ -411,7 +424,7 @@ kubectl create serviceaccount <your-namespace>-kpo -n airflow-kpo-default
 This step will differ depending on the Airflow setup. When running Airflow locally it is just necessary to make sure `awscli`, `apache-airflow-providers-cncf-kubernetes`,
 and `apache-airflow-providers-amazon` are installed correctly on the local machine.
 
-For dockerized settings add the following line to your Dockerfile:
+For dockerized settings add the following line to your Dockerfile to copy your aws credentials :
 
 ```dockerfile
 COPY --chown=astro:astro include/.aws /home/astro/.aws
@@ -434,7 +447,7 @@ In the Airflow UI navigate to **Admin** -> **Connections** to set up the connect
 
 ### Step 6 Add the DAG interacting with EKS  
 
-If dynamic behavior of the EKS cluster is desired, e.g. nodes get created with specifications for a task and deleted after the task has run, it is necessary to use several classes from the Amazon provider package. The DAG below has 5 tasks. The first one creates a nodegroup according to the users' specifications and afterwards a sensor checks that the cluster is running correctly. The third tasks is the actual KubernetesPodOperator running any valid Docker image. Lastly the nodegroup gets deleted and the deletion gets verified.
+If dynamic behavior of the EKS cluster is desired, e.g. Nodes get created with specifications for a task and deleted after the task has run, it is necessary to use several classes from the Amazon provider package. The DAG below has 5 tasks. The first one creates a Nodegroup according to the users' specifications and afterwards a sensor checks that the cluster is running correctly. The third tasks is the actual KubernetesPodOperator running any valid Docker image. Lastly the Nodegroup gets deleted and the deletion gets verified.
 
 ```python
 # import DAG object and utility packages
@@ -443,7 +456,7 @@ from datetime import datetime
 from airflow.configuration import conf
 
 # import the KPO
-from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import (
+from airflow.providers.cncf.kubernetes.operators.kubernetes_Pod import (
                                                         KubernetesPodOperator)
 
 # import EKS related packages from the Amazon Provider
@@ -517,15 +530,17 @@ with DAG(
         task_id="run_on_EKS",
         cluster_context='<arn of your cluster>',
         namespace="airflow-kpo-default",
-        name="example_pod",
+        name="example_Pod",
         image='ubuntu',
         cmds=['bash', '-cx'],
         arguments=["echo hello"],
         get_logs=True,
-        is_delete_operator_pod=False,
+        is_delete_operator_Pod=False,
         in_cluster=False,
         config_file='/usr/local/airflow/include/config',
-        startup_timeout_seconds=240
+        startup_timeout_seconds=240,
+        # this line is specific to users of Astro and not needed in OSS Airflow
+        labels={"kubernetes_pod_operator": "external-cluster"}
     )
 
     # task 4 deleting the nodegroup

--- a/guides/kubepod-operator.md
+++ b/guides/kubepod-operator.md
@@ -9,9 +9,9 @@ tags: ["Kubernetes", "Operators"]
 
 ## Overview
 
-The [`KubernetesPodOperator`](https://registry.astronomer.io/providers/kubernetes/modules/kubernetespodoperator) (KPO) is an operator from the Kubernetes provider package designed to provide a straightforward way to execute a task in a Kubernetes pod from your Airflow environment. In a nutshell, the KPO is an abstraction over a call to the Kubernetes API to launch a pod.
+The [`KubernetesPodOperator`](https://registry.astronomer.io/providers/kubernetes/modules/kubernetesPodoperator) (KPO) is an operator from the Kubernetes provider package designed to provide a straightforward way to execute a task in a Kubernetes Pod from your Airflow environment. In a nutshell, the KPO is an abstraction over a call to the Kubernetes API to launch a Pod.
 
-In this guide, we list the requirements to run the `KubernetesPodOperator`, explain when to use it and cover its most important arguments, as well as the difference between the KPO and `KubernetesExecutor`. We also provide concrete examples on how to use the KPO to run a task in a language other than Python, how to use the KPO with XComs, and how to launch a pod in a remote AWS EKS Cluster.  
+In this guide, we list the requirements to run the `KubernetesPodOperator`, explain when to use it and cover its most important arguments, as well as the difference between the KPO and `KubernetesExecutor`. We also provide concrete examples on how to use the KPO to run a task in a language other than Python, how to use the KPO with XComs, and how to launch a Pod in a remote AWS EKS Cluster.  
 
 > **Note**: Kubernetes is a powerful tool for Container Orchestration with complex functionality. If you are unfamiliar with Kubernetes we recommend taking a look at the [Kubernetes 101 Guide](https://www.astronomer.io/guides/intro-to-kubernetes/) to get a general overview. For in-depth information check out the [Kubernetes Documentation](https://kubernetes.io/docs/home/).  
 
@@ -25,7 +25,7 @@ pip install apache-airflow-providers-cncf-kubernetes==<version>
 
 To double check which version of the Kubernetes provider package is compatible with your version of Airflow and to view dependencies that will be installed automatically please refer to the [Airflow Kubernetes provider Documentation](https://airflow.apache.org/docs/apache-airflow-providers-cncf-kubernetes/stable/index.html#requirements).
 
-You will also need an existing Kubernetes cluster to connect to, which commonly but not necessarily is the same cluster that Airflow is running on. It is _not_ necessary to use the Kubernetes Executor in order to use the KPO. You may use any of the following executors: `CeleryExecutor`, `KubernetesExecutor`, [`CeleryKubernetesExecutor`](https://airflow.apache.org/docs/apache-airflow/2.0.0/executor/celery_kubernetes.html). When using Celery remember to install its [provider](https://registry.astronomer.io/providers/celery).
+You will also need an existing Kubernetes cluster to connect to, which commonly but not necessarily is the same cluster that Airflow is running on. It is _not_ necessary to use the Kubernetes Executor in order to use the KPO. You may use any of the following executors: `LocalExecutor`, `LocalKubernetesExecutor`, `CeleryExecutor`, `KubernetesExecutor`, [`CeleryKubernetesExecutor`](https://airflow.apache.org/docs/apache-airflow/2.0.0/executor/celery_kubernetes.html). When using Celery remember to install its [provider](https://registry.astronomer.io/providers/celery).
 
 > **Note**: On Astro, the infrastructure needed to run KPO with CeleryExecutor is pre-built into every cluster. Astronomer provides [comprehensive documentation on using the KPO on Astro](https://docs.astronomer.io/astro/kubernetespodoperator).  
 
@@ -33,11 +33,11 @@ You will also need an existing Kubernetes cluster to connect to, which commonly 
 
 When developing and testing changes it can be tedious to deploy to a remote environment, which is why many users set up their local dev environment to support usage of the KPO. This can be accomplished in several ways.
 
-For users of the Astro CLI there is a [step-by-step tutorial](https://docs.astronomer.io/software/kubePodoperator-local) available in the Astro Documentation, which can also be adapted for other dockerized Airflow setups.
+For users of the Astro CLI there is a [step-by-step tutorial](https://docs.astronomer.io/software/kubepodoperator-local) available in the Astro Documentation, which can also be adapted for other dockerized Airflow setups.
 
 It is also possible to run open source Airflow within a local Kubernetes cluster using the [Helm Chart for Apache Airflow](https://airflow.apache.org/docs/helm-chart/stable/index.html). For a walkthrough of this setup you can refer to the recording of the [Getting Started With the Official Airflow Helm Chart Webinar](https://www.youtube.com/watch?v=39k2Sz9jZ2c&ab_channel=Astronomer).
 
-When running Airflow within a Kubernetes cluster, using the KPO does not require further configuration beyond leaving the `KubernetesPodOperator` parameter `in_cluster` on its default setting (`True`) to run a new pod within the same cluster. An example on how to run a pod on a remote cluster, including in the case of not running local Airflow on Kubernetes, is presented at the end of this guide.
+When running Airflow within a Kubernetes cluster, using the KPO does not require further configuration beyond leaving the `KubernetesPodOperator` parameter `in_cluster` on its default setting (`True`) to run a new Pod within the same cluster. An example on how to run a Pod on a remote cluster, including in the case of not running local Airflow on Kubernetes, is presented at the end of this guide.
 
 ## When to use the `KubernetesPodOperator`
 
@@ -47,9 +47,9 @@ The `KubernetesPodOperator` runs any Docker image provided to it, whether they a
 - Having full control over how much compute resources and memory a single task can use.
 - Executing tasks in an separate environment with individual packages and dependencies.
 - Running tasks that necessitate using a version of Python not supported by your Airflow environment.
-- Running tasks with specific node (a virtual or physical machine in Kubernetes) constrains such as only running on nodes located in the European Union.
+- Running tasks with specific Node (a virtual or physical machine in Kubernetes) constrains such as only running on Nodes located in the European Union.
 
-Sometimes you may want to run pods on different clusters, for example if only some need GPU resources while others do not. This is also possible with the KPO and a step-by-step example is provided at the end of this guide.
+Sometimes you may want to run Pods on different clusters, for example if only some need GPU resources while others do not. This is also possible with the KPO and a step-by-step example is provided at the end of this guide.
 
 > **Note**: A simple way to execute tasks in different clusters with different compute resources using worker queues is an upcoming feature on Astro!
 
@@ -57,45 +57,45 @@ Sometimes you may want to run pods on different clusters, for example if only so
 
 In Airflow you have the option to choose between a variety of [executors](https://www.astronomer.io/guides/airflow-executors-explained) which determine how your Airflow tasks will be executed.
 
-The [KubernetesExecutor](https://airflow.apache.org/docs/apache-airflow/stable/executor/kubernetes.html) and the `KubernetesPodOperator` both dynamically launch and terminate pods to run Airflow tasks. As the names suggest, `KubernetesExecutor` is an executor, which means it affects how all tasks in an Airflow instance are executed, while the `KubernetesPodOperator` is an operator defining that a single task is to be launched in a Kubernetes pod with the given configuration and does not affect any other tasks in the Airflow instance.
+The `KubernetesExecutor` and the `KubernetesPodOperator` both dynamically launch and terminate Pods to run Airflow tasks. As the names suggest, `KubernetesExecutor` is an executor, which means it affects how all tasks in an Airflow instance are executed, while the `KubernetesPodOperator` is an operator defining that a single task is to be launched in a Kubernetes Pod with the given configuration and does not affect any other tasks in the Airflow instance. Details on how to configure the `KubernetesExecutor` can be found in the [Airflow Documentation](https://airflow.apache.org/docs/apache-airflow/stable/executor/kubernetes.html).
 
 Compared to the KPO, the `KubernetesExecutor`:
 
-- Runs Airflow tasks in a Kubernetes pod without the user needing to specify a Docker image.
-- Is implemented at the configuration level of the Airflow instance, which means _all_ tasks will each be run in their own Kubernetes pod. This may be desired in some use cases to leverage auto-scaling, but is generally not ideal for environments with a high volume of shorter running tasks.
-- Has less abstraction over pod configuration. All task-level configurations have to be passed in as a dictionary via the `BaseOperator` argument `executor_config`, which is available to all operators. Details on configuring the `KubernetesExecutor` can be found in the [Airflow documentation](https://airflow.apache.org/docs/apache-airflow/stable/executor/kubernetes.html).
-- If a custom Docker image is passed to the `KubernetesExecutor`, it needs to have Airflow installed, otherwise the task will not run. This is not the case with the KPO, which can run any valid Docker image.
+- Runs Airflow tasks in a Kubernetes Pod without the user needing to specify a Docker image.
+- Is implemented at the configuration level of the Airflow instance, which means _all_ tasks will each be run in their own Kubernetes Pod. This may be desired in some use cases to leverage auto-scaling, but is generally not ideal for environments with a high volume of shorter running tasks.
+- Has less abstraction over Pod configuration. All task-level configurations have to be passed in as a dictionary via the `BaseOperator` argument `executor_config`, which is available to all operators.
+- If a custom Docker image is passed to the `KubernetesExecutor`'s `base` container by providing it to either the `pod_template_file` or the `pod_override` key in the dictionary for the `executor_config` argument, it needs to have Airflow installed, otherwise the task will not run. A possible reason for customizing this Docker image would be to run a task in an environment with different versions of packages than the majority of the tasks an Airflow instance. This is not the case with the KPO, which can run any valid Docker image.
 
-Both the `KubernetesPodOperator` and the `KubernetesExecutor` can use the entire Kubernetes API with regards to pod creation. Which one to use is an individual choice based on the user's requirements and preferences. You can think of the KPO as "Docker image first" and the `KubernetesExecutor` as "operator first" implementations. The KPO is generally ideal for controlling the environment the task is run in, while the `KubernetesExecutor` is ideal for controlling resource optimization. Frequently the KPO is used in an Airflow environment using the `KubernetesExecutor` to run some tasks where the focus is on environment control while the other tasks are run in pods via the `KubernetesExecutor`.
+Both the `KubernetesPodOperator` and the `KubernetesExecutor` can use the entire Kubernetes API with regards to Pod creation. Which one to use is an individual choice based on the user's requirements and preferences. You can think of the KPO as "Docker image first" and the `KubernetesExecutor` as "operator first" implementations. The KPO is generally ideal for controlling the environment the task is run in, while the `KubernetesExecutor` is ideal for controlling resource optimization. Frequently the KPO is used in an Airflow environment using the `KubernetesExecutor` to run some tasks where the focus is on environment control while the other tasks are run in Pods via the `KubernetesExecutor`.
 
 ## How to configure the `KubernetesPodOperator`
 
-The KPO launches any valid Docker Image provided to it (passed via the `image` parameter) in a new Kubernetes pod on an existing Kubernetes cluster. The operator has many other parameters which specify the pod configuration which the KPO translates into a call to the [Kubernetes API](https://kubernetes.io/docs/reference/kubernetes-api/). The `KubernetesPodOperator` offers full access to Kubernetes API functionality relating to pod creation.    
+The KPO launches any valid Docker Image provided to it (passed via the `image` parameter) in a new Kubernetes Pod on an existing Kubernetes cluster. The operator has many other parameters which specify the Pod configuration which the KPO translates into a call to the [Kubernetes API](https://kubernetes.io/docs/reference/kubernetes-api/). The `KubernetesPodOperator` offers full access to Kubernetes API functionality relating to Pod creation.    
 
 The `KubernetesPodOperator` can be instantiated like any other operator within the context of a DAG. The following are some of the arguments that can be passed to the operator.
 
 **Mandatory arguments** are:
 
 - `task_id`: a unique string identifying the task within Airflow.
-- `namespace`: the namespace within your Kubernetes cluster the new pod should be assigned to.
-- `name`: the name of the pod created. This name needs to be unique for each pod within a namespace.
+- `namespace`: the namespace within your Kubernetes cluster the new Pod should be assigned to.
+- `name`: the name of the Pod created. This name needs to be unique for each Pod within a namespace.
 - `image`: a Docker image to launch. Images from [hub.docker.com](https://hub.docker.com/) can be passed in with just the image name, custom repositories have to be given as full URLs.
 
 Commonly used **optional arguments** include:
 
-- `random_name_suffix`: generates a random suffix for the pod name if set to `True`. Avoids naming conflicts when running a large number of pods.
-- `labels`: add key:value pairs to the pod which can be used to logically group decoupled objects together.
-- `ports`: provides the possibility to override default ports for the pod.
-- `reattach_on_restart`: defines how to handle losing the worker while the pod is running, by default (`True`) the existing pod will reattach to the worker on the next try. `False` creates a new pod for each try.
-- `is_delete_operator_pod`: `True` by default, will delete the pod when it reaches its final state or when the execution is interrupted.
+- `random_name_suffix`: generates a random suffix for the Pod name if set to `True`. Avoids naming conflicts when running a large number of Pods.
+- `labels`: add key:value pairs to the Pod which can be used to logically group decoupled objects together.
+- `ports`: provides the possibility to override default ports for the Pod.
+- `reattach_on_restart`: defines how to handle losing the worker while the Pod is running, by default (`True`) the existing Pod will reattach to the worker on the next try. `False` creates a new Pod for each try.
+- `is_delete_operator_pod`: `True` by default, will delete the Pod when it reaches its final state or when the execution is interrupted.
 - `get_logs`: provides the `stdout` of the container as task-logs to the Airflow logging system.
-- `log_events_on_failure`: if set to `True` events will be logged in case the pod fails (default: `False`).
-- `env_vars`: allows the user to specify individual environment variables for a pod.
+- `log_events_on_failure`: if set to `True` events will be logged in case the Pod fails (default: `False`).
+- `env_vars`: allows the user to specify individual environment variables for a Pod.
 - `resources`: allows the user to pass a dictionary with resource requests (keys: `request_memory`, `request_cpu`) and limits (keys: `limit_memory`, `limit_cpu`, `limit_gpu`). See the [Kubernetes Documentation on Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for more information.
 - `volumes`: can be used to pass in a modified `k8s.V1Volume`, see also the [Kubernetes example DAG from the Airflow documentation](https://airflow.apache.org/docs/apache-airflow-providers-cncf-kubernetes/stable/_modules/tests/system/providers/cncf/kubernetes/example_kubernetes.html).
-- `affinity` and `tolerations` are ways to further specify rules for [pod to node assignment](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-Pod-node/). Like the `volumes` parameter they also require their input as a `k8s` object.
+- `affinity` and `tolerations` are ways to further specify rules for [Pod to Node assignment](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/). Like the `volumes` parameter they also require their input as a `k8s` object.
 
-There are also many other arguments that can be used to configure the pod and pass information to the Docker image. For example, the 'Spinning up a pod in EKS from Airflow' section below shows how to define an entrypoint (`cmds`) and its arguments (`arguments`) for your container.
+There are also many other arguments that can be used to configure the Pod and pass information to the Docker image. For example, the 'Spinning up a Pod in EKS from Airflow' section below shows how to define an entrypoint (`cmds`) and its arguments (`arguments`) for your container.
 
 > **Note**: The following KPO arguments can be used with Jinja templates: `image`, `cmds`, `arguments`, `env_vars`, `labels`, `config_file`, `pod_template_file`, and `namespace`.
 
@@ -103,9 +103,9 @@ There are also many other arguments that can be used to configure the pod and pa
 
 ### Configuring Kubernetes Connection
 
-When leaving the `in_cluster` parameter on its default setting (`True`) it is not necessary to further configure the Kubernetes connection, the pod specified by the `KubernetesPodOperator` will be run on the same Kubernetes cluster as your Airflow instance is running on.
+When leaving the `in_cluster` parameter on its default setting (`True`) it is not necessary to further configure the Kubernetes connection, the Pod specified by the `KubernetesPodOperator` will be run on the same Kubernetes cluster as your Airflow instance is running on.
 
-If you are not running Airflow on Kubernetes or want to send the pod to a different cluster than the one currently hosting your Airflow instance the three arguments below will be necessary to specify how the KPO will use the [Kubernetes Hook](https://registry.astronomer.io/providers/kubernetes/modules/kuberneteshook) to connect to the [Kubernetes API](https://kubernetes.io/docs/reference/kubernetes-api/) of a different Kubernetes cluster.
+If you are not running Airflow on Kubernetes or want to send the Pod to a different cluster than the one currently hosting your Airflow instance the three arguments below will be necessary to specify how the KPO will use the [Kubernetes Hook](https://registry.astronomer.io/providers/kubernetes/modules/kuberneteshook) to connect to the [Kubernetes API](https://kubernetes.io/docs/reference/kubernetes-api/) of a different Kubernetes cluster.
 
 - `kubernetes_conn_id`: uses a [connection](https://www.astronomer.io/guides/connections) stored in the [Airflow metadata database](https://www.astronomer.io/guides/airflow-database), which can be configured in the Airflow UI under **Admin** -> **Connections**.
 - `config_file`: sets the path to the `KubeConfig` file. If not specified, the default value is `~/.kube/config`.
@@ -174,26 +174,26 @@ with DAG(
         # the Docker image to launch
         image='<image location>',
 
-        ## arguments pertaining to where the pod is launched
-        # launch the pod on the same cluster as Airflow is running on
+        ## arguments pertaining to where the Pod is launched
+        # launch the Pod on the same cluster as Airflow is running on
         in_cluster=True,
-        # launch the pod in the same namespace as Airflow is running in
+        # launch the Pod in the same namespace as Airflow is running in
         namespace=namespace,
 
-        ## pod configuration
-        # name the pod
+        ## Pod configuration
+        # name the Pod
         name='my_pod',
-        # give the pod name a random suffix, ensure uniqueness in the namespace
+        # give the Pod name a random suffix, ensure uniqueness in the namespace
         random_name_suffix=True,
-        # attach labels to the pod, can be used for grouping
+        # attach labels to the Pod, can be used for grouping
         labels={'app':'backend', 'env':'dev'},
-        # reattach to worker instead of creating a new pod on worker failure
+        # reattach to worker instead of creating a new Pod on worker failure
         reattach_on_restart=True,
-        # delete pod after the task is finished
+        # delete Pod after the task is finished
         is_delete_operator_pod=True,
         # get log stdout of the container as task logs
         get_logs=True,
-        # log events in case of pod failure
+        # log events in case of Pod failure
         log_events_on_failure=True,
         # pass your name as an environment var
         env_vars={"NAME_TO_GREET": f"{name}"}
@@ -290,14 +290,14 @@ with DAG(
         # arguments pertaining to the image and commands executed
         image='< image location >', # the Docker Image to launch
 
-        # arguments pertaining to where the pod is launched
-        in_cluster=True, # launch the pod on the same cluster as Airflow is running on
-        namespace=namespace, # launch the pod in the same namespace as Airflow is running in
+        # arguments pertaining to where the Pod is launched
+        in_cluster=True, # launch the Pod on the same cluster as Airflow is running on
+        namespace=namespace, # launch the Pod in the same namespace as Airflow is running in
 
-        # pod configuration
-        name='my_pod', # naming the pod
+        # Pod configuration
+        name='my_pod', # naming the Pod
         get_logs=True, # log stdout of the container as task logs
-        log_events_on_failure=True, #log events in case of pod failure
+        log_events_on_failure=True, #log events in case of Pod failure
         env_vars={"DATA_POINT": "{{ ti.xcom_pull(task_ids='extract_data', key='return_value') }}"},
         do_xcom_push=True #push the contents from xcom.json to xcoms
         )
@@ -314,9 +314,9 @@ with DAG(
 
 If some of your tasks require specific resources like a GPU you may want to run them in a different cluster than your Airflow Instance. In setups where both clusters are used by the same AWS or GCP account, this can be managed with roles and permissions. There is also the possibility to use a CI account and enable [cross-account access to AWS EKS cluster resources](https://aws.amazon.com/blogs/containers/enabling-cross-account-access-to-amazon-eks-cluster-resources/).  
 
-However, you may want to use a specific AWS or GCP account that you keep separate from your Airflow environment. Or you are currently running Airflow on a local setup not using Kubernetes, but still want to run some tasks in a Kubernetes pod on a remote cluster.
+However, you may want to use a specific AWS or GCP account that you keep separate from your Airflow environment. Or you are currently running Airflow on a local setup not using Kubernetes, but still want to run some tasks in a Kubernetes Pod on a remote cluster.
 
-The example below shows the steps to take to set up an EKS cluster on AWS and run a pod on it from an Airflow instance where cross-account access is not feasible. After setup of the EKS cluster, the `KubeConfig` as well as the `AWS Profile` have to be provided to Airflow to make the connection to the remote cluster. Note that the same general steps are applicable to other Kubernetes services (e.g. GKE).  
+The example below shows the steps to take to set up an EKS cluster on AWS and run a Pod on it from an Airflow instance where cross-account access is not feasible. After setup of the EKS cluster, the `KubeConfig` as well as the `AWS Profile` have to be provided to Airflow to make the connection to the remote cluster. Note that the same general steps are applicable to other Kubernetes services (e.g. GKE).  
 
 > **Note**: If you are using [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/) consider using [GKEStartPodOperator](https://registry.astronomer.io/providers/google/modules/gkestartPodoperator).
 
@@ -413,7 +413,7 @@ The `KubeConfig` file is how the KPO will connect to a Kubernetes cluster by run
 
 ### Step 3: Add a namespace and service account to the EKS Cluster
 
-It is best practice to use a new namespace and separate service account for all pods sent to the EKS cluster from the Airflow environment.  
+It is best practice to use a new namespace and separate service account for all Pods sent to the EKS cluster from the Airflow environment.  
 
 ```bash
 # create a new namespace on the EKS cluster
@@ -451,7 +451,7 @@ apache-airflow-providers-amazon
 
 In the Airflow UI navigate to **Admin** -> **Connections** to set up the connection to the AWS account running the target EKS cluster. Chose a unique connection ID and use your `aws_access_key_id` as login and your `aws_secret_access_key` as password.
 
-![Adding AWS connection](https://assets2.astronomer.io/main/guides/your-guide-folder/aws_connection.png)
+![Adding AWS connection](https://assets2.astronomer.io/main/guides/kubepod-operator/aws_connection.png)
 
 ### Step 6: Create the DAG with the KPO
 
@@ -459,11 +459,11 @@ If dynamic behavior of the EKS cluster is desired, e.g. Nodes get created with s
 
 The example DAG contains 5 consecutive tasks:
 
-- Create a nodegroup according to the users' specifications.
+- Create a node group according to the users' specifications.
 - Use a sensor to check that the cluster is running correctly.
-- Use the `KubernetesPodOperator` to run any valid Docker image in a pod on the newly created nodegroup on the remote cluster. The example DAG uses the standard `Ubuntu` image to print "hello" to the console using a `bash` command.
-- Delete the nodegroup.
-- Verify that the nodegroup has been deleted.
+- Use the `KubernetesPodOperator` to run any valid Docker image in a Pod on the newly created node group on the remote cluster. The example DAG uses the standard `Ubuntu` image to print "hello" to the console using a `bash` command.
+- Delete the node group.
+- Verify that the node group has been deleted.
 
 > **Note**: The argument `labels={"kubernetes_pod_operator": "external-cluster"}` in the KPO of the example DAG is specific to behavior of the Astro Cloud and not needed for other implementations.
 
@@ -483,7 +483,7 @@ from airflow.providers.amazon.aws.operators.eks import (
                       EKSCreateNodegroupOperator, EKSDeleteNodegroupOperator)
 from airflow.providers.amazon.aws.sensors.eks import EKSNodegroupStateSensor
 
-# custom class to create a nodegroup with Nodes on EKS
+# custom class to create a node group with Nodes on EKS
 class EKSCreateNodegroupWithNodesOperator(EKSCreateNodegroupOperator):
 
     def execute(self, context):
@@ -493,7 +493,7 @@ class EKSCreateNodegroupWithNodesOperator(EKSCreateNodegroupOperator):
             region_name=self.region,
         )
 
-        # define the node group to create
+        # define the Node group to create
         eks_hook.create_nodegroup(
             clusterName=self.cluster_name,
             nodegroupName=self.nodegroup_name,
@@ -520,7 +520,7 @@ with DAG(
     dag_id='a_dag_in_k8s'
 ) as dag:
 
-    # task 1 creates the nodegroup
+    # task 1 creates the node group
     create_gpu_nodegroup=EKSCreateNodegroupWithNodesOperator(
         task_id='create_gpu_nodegroup',
         cluster_name='<your cluster name>',  
@@ -531,7 +531,7 @@ with DAG(
         region='<your region>'
     )
 
-    # task 2 check for nodegroup status, if it is up and running
+    # task 2 check for node group status, if it is up and running
     check_nodegroup_status=EKSNodegroupStateSensor(
         task_id='check_nodegroup_status',
         cluster_name='<your cluster name>',
@@ -561,7 +561,7 @@ with DAG(
         labels={"kubernetes_pod_operator": "external-cluster"}
     )
 
-    # task 4 deleting the nodegroup
+    # task 4 deleting the node group
     delete_gpu_nodegroup=EKSDeleteNodegroupOperator(
         task_id='delete_gpu_nodegroup',
         cluster_name='<your cluster name>',  
@@ -570,7 +570,7 @@ with DAG(
         region='<your region>'
     )
 
-    # task 5 checking that the nodegroup was deleted successfully
+    # task 5 checking that the node group was deleted successfully
     check_nodegroup_termination=EKSNodegroupStateSensor(
         task_id='check_nodegroup_termination',
         cluster_name='<your cluster name>',
@@ -586,3 +586,7 @@ with DAG(
     create_gpu_nodegroup >> check_nodegroup_status >> run_on_EKS
     run_on_EKS >> delete_gpu_nodegroup >> check_nodegroup_termination
 ```
+
+It is possible to view the remote Pod while it runs using `kubectl` (if the local command line connection to the remote cluster has been configured):
+
+![Kubectl remote Pod running](https://assets2.astronomer.io/main/guides/kubepod-operator/kubectl_remote_pod.png)

--- a/guides/kubepod-operator.md
+++ b/guides/kubepod-operator.md
@@ -16,7 +16,7 @@ In this guide, we cover:
 - The requirements for running the `KubernetesPodOperator`.
 - When to use the `KubernetesPodOperator`.
 - How to configure the `KubernetesPodOperator`.
-- The differences between the `KubernetesPodOperator` and the Kubernetes executor. 
+- The differences between the `KubernetesPodOperator` and the Kubernetes executor.
 
 We also provide examples of how to use the KPO to run a task in a language other than Python, how to use the KPO with XComs, and how to launch a Pod in a remote AWS EKS Cluster.  
 
@@ -32,14 +32,14 @@ pip install apache-airflow-providers-cncf-kubernetes==<version>
 
 Make sure you install the right version of the provider package for your version of Airflow by checking the [Airflow Kubernetes provider Documentation](https://airflow.apache.org/docs/apache-airflow-providers-cncf-kubernetes/stable/index.html#requirements).
 
-You also need an existing Kubernetes cluster to connect to. This is commonly the same cluster that Airflow is running on, but it doesn't have to be. 
+You also need an existing Kubernetes cluster to connect to. This is commonly the same cluster that Airflow is running on, but it doesn't have to be.
 
-You don't need to use the Kubernetes executor to use the KPO. You can use any of the following executors: 
+You don't need to use the Kubernetes executor to use the KPO. You can use any of the following executors:
 - Local executor
 - LocalKubernetes executor
 - Celery executor
 - Kubernetes executor
-- CeleryKubernetes executor 
+- CeleryKubernetes executor
 
 When using Celery, remember to install its [provider](https://registry.astronomer.io/providers/celery).
 
@@ -329,7 +329,7 @@ This example shows how to set up an EKS cluster on AWS and run a Pod on it from 
 
 ### Step 1: Set up an EKS cluster on AWS
 
-To set up a new EKS cluster on AWS, first [create an EKS cluster IAM role](https://docs.aws.amazon.com/eks/latest/userguide/service_IAM_role.html#create-service-role) with a unique name and to the following permission policies: 
+To set up a new EKS cluster on AWS, first [create an EKS cluster IAM role](https://docs.aws.amazon.com/eks/latest/userguide/service_IAM_role.html#create-service-role) with a unique name and to the following permission policies:
 
 - `AmazonEKSWorkerNodePolicy`
 - `AmazonEKS_CNI_Policy`
@@ -369,9 +369,9 @@ source_profile = <your user>
 
 Make sure your default credentials include a valid and active key for your username (see the [AWS docs](https://docs.aws.amazon.com/kms/latest/developerguide/create-keys.html) for more information).
 
-Make a copy of `~/.aws/credentials` available to your Airflow environment. If you run Airflow using the Astro CLI, copy this file into the `include` folder of your Astro project. 
+Make a copy of `~/.aws/credentials` available to your Airflow environment. If you run Airflow using the Astro CLI, copy this file into the `include` folder of your Astro project.
 
-Lastly, [create a new EKS cluster](https://docs.aws.amazon.com/eks/latest/userguide/create-cluster.html) and assign the the newly created role to it. 
+Lastly, [create a new EKS cluster](https://docs.aws.amazon.com/eks/latest/userguide/create-cluster.html) and assign the the newly created role to it.
 
 ### Step 2: Retrieve the KubeConfig file from the EKS cluster
 
@@ -381,9 +381,9 @@ Use a `KubeConfig` file to remotely connect to your new EKS cluster. Retrieve it
 aws eks --region <your-region> update-kubeconfig --name <cluster-name>
 ```
 
-This command copies information relating to the new cluster into your existing `KubeConfig` file at `~/.kube/config`. 
+This command copies information relating to the new cluster into your existing `KubeConfig` file at `~/.kube/config`.
 
-Check this file before making it available to Airflow. It should look like the following configuration. If any of the configurations listed here are missing, add them to the file. 
+Check this file before making it available to Airflow. It should look like the following configuration. If any of the configurations listed here are missing, add them to the file.
 
 ```text
 apiVersion: v1
@@ -432,9 +432,9 @@ kubectl create namespace <your-namespace-name>
 
 ### Step 4: Adjust the Airflow configuration files
 
-This step will differ depending on the Airflow setup. 
+This step will differ depending on the Airflow setup.
 
-#### Local Apache Airflow 
+#### Local Apache Airflow
 
 To access your cluster from local instance of Apache Airflow, install `awscli`, `apache-airflow-providers-cncf-kubernetes`, and `apache-airflow-providers-amazon` on the machine running Airflow.
 
@@ -461,9 +461,9 @@ apache-airflow-providers-amazon
 
 ### Step 5: Add AWS connection ID
 
-In the Airflow UI, go to **Admin** -> **Connections** to set up the connection to the AWS account running the target EKS cluster. Set the following configurations for the connection: 
+In the Airflow UI, go to **Admin** -> **Connections** to set up the connection to the AWS account running the target EKS cluster. Set the following configurations for the connection:
 - **Connection ID**: Any
-- **Connection Type**: Amazon Web Services 
+- **Connection Type**: Amazon Web Services
 - **Login**: Your AWS access key ID
 - **Password**: Your AWS secret access key
 

--- a/guides/kubepod-operator.md
+++ b/guides/kubepod-operator.md
@@ -11,11 +11,11 @@ tags: ["Kubernetes", "Operators"]
 
 The [KubernetesPodOperator](https://registry.astronomer.io/providers/kubernetes/modules/kubernetesPodoperator) (KPO) is an operator from the Kubernetes provider package designed to provide a straightforward way to execute a task in a Kubernetes Pod from your Airflow environment. In a nutshell the KPO is an abstraction over a call to the Kubernetes API to launch a Pod.
 
-In this guide we will list the requirements to run the KubernetesPodOperator, explain when to use it and cover its most important arguments, as well as the difference between the KPO and KubernetesExecutor. We will also provide concrete examples on how to use the KPO to run a task in a language other than Python, how to use the KPO with XComs and how to launch a Pod in a remote AWS EKS Cluster.  
+In this guide, we list the requirements to run the KubernetesPodOperator, explain when to use it and cover its most important arguments, as well as the difference between the KPO and KubernetesExecutor. We also provide concrete examples on how to use the KPO to run a task in a language other than Python, how to use the KPO with XComs, and how to launch a pod in a remote AWS EKS Cluster.  
 
 > **Note**: Kubernetes is a powerful tool for Container Orchestration with complex functionality. If you are unfamiliar with Kubernetes we recommend taking a look at the [Kubernetes 101 Guide](https://www.astronomer.io/guides/intro-to-kubernetes/) to get a general overview. For in-depth information check out the [Kubernetes Documentation](https://kubernetes.io/docs/home/).  
 
-## Requirements to use the KubernetesPodOperator
+## Requirements For Using the KubernetesPodOperator
 
 To use the KubernetesPodOperator it is necessary to install the Kubernetes provider package.
 
@@ -27,15 +27,15 @@ Required versions of the `apache-airflow`, `cryptography` and `kubernetes` packa
 
 You will also need an existing Kubernetes cluster to connect to. It is _not_ necessary to use the Kubernetes Executor in order to use the KPO. You may use any of the following executors: `CeleryExecutor`, `KubernetesExecutor`, [`CeleryKubernetesExecutor`](https://airflow.apache.org/docs/apache-airflow/2.0.0/executor/celery_kubernetes.html). When using Celery remember to install its [provider](https://registry.astronomer.io/providers/celery).
 
-> **Note**: On Astro the infrastructure needed to run KPO with CeleryExecutor is pre-built into every Cluster. Astronomer provides [comprehensive documentation on using the KPO on Astro](https://docs.astronomer.io/astro/kubernetesPodoperator).  
+> **Note**: On Astro, the infrastructure needed to run KPO with CeleryExecutor is pre-built into every cluster. Astronomer provides [comprehensive documentation on using the KPO on Astro](https://docs.astronomer.io/astro/kubernetesPodoperator).  
 
-### The KubernetesPodOperator in local development
+### Running the KubernetesPodOperator Locally
 
 There are several ways in which the KubernetesPodOperator can be run in local development. For users of the Astro CLI there is a [step-by-step tutorial](https://docs.astronomer.io/software/kubePodoperator-local) available in the Astro Documentation, which can also be adapted for other dockerized Airflow setups.
 
-It is also possible to run Open Source Airflow within a local Kubernetes Cluster using the [Helm Chart for Apache Airflow](https://airflow.apache.org/docs/helm-chart/stable/index.html). For a walkthrough of this setup you can refer to the recording of the [Getting Started With the Official Airflow Helm Chart Webinar](https://www.youtube.com/watch?v=39k2Sz9jZ2c&ab_channel=Astronomer).
+It is also possible to run open source Airflow within a local Kubernetes cluster using the [Helm Chart for Apache Airflow](https://airflow.apache.org/docs/helm-chart/stable/index.html). For a walkthrough of this setup you can refer to the recording of the [Getting Started With the Official Airflow Helm Chart Webinar](https://www.youtube.com/watch?v=39k2Sz9jZ2c&ab_channel=Astronomer).
 
-When running Airflow within a Kubernetes cluster using the KPO does not require further configuration beyond leaving the setting `in_cluster` on `True` to run a new Pod within the same cluster. An example on how to run a Pod on a remote cluster, including in the case of not running local Airflow on Kubernetes, is presented at the end of this guide.
+When running Airflow within a Kubernetes cluster, using the KPO does not require further configuration beyond leaving the setting `in_cluster` on `True` to run a new pod within the same cluster. An example on how to run a pod on a remote cluster, including in the case of not running local Airflow on Kubernetes, is presented at the end of this guide.
 
 ## When to use the KubernetesPodOperator
 
@@ -45,9 +45,9 @@ The KubernetesPodOperator runs any Docker image provided to it, whether they are
 - Having full control over how much compute resources and memory a single task can use.
 - Executing tasks in an separate environment with individual packages and dependencies.
 - Running tasks that necessitate using a version of Python not supported by your Airflow environment.
-- Running tasks with specific Node (a virtual or physical machine in Kubernetes) constrains such as only running on Nodes located in the European Union.
+- Running tasks with specific node (a virtual or physical machine in Kubernetes) constrains such as only running on nodes located in the European Union.
 
-Sometimes you may want to run Pods on different clusters, for example if only some need GPU resources while others do not. This is also possible with the KPO and a step-by-step example is provided at the end of this guide.
+Sometimes you may want to run pods on different clusters, for example if only some need GPU resources while others do not. This is also possible with the KPO and a step-by-step example is provided at the end of this guide.
 
 > **Note**: A simple way to execute tasks in different clusters with different compute resources using worker queues is an upcoming feature on Astro!
 
@@ -55,30 +55,32 @@ Sometimes you may want to run Pods on different clusters, for example if only so
 
 In Airflow you have the option to choose between a variety of [executors](https://www.astronomer.io/guides/airflow-executors-explained) which determine how your Airflow tasks will be executed.
 
-The [KubernetesExecutor](https://airflow.apache.org/docs/apache-airflow/stable/executor/kubernetes.html) and the KubernetesPodOperator both dynamically launch and terminate Pods to run Airflow tasks in. As the names suggest, KubernetesExecutor is an executor, which means it affects how all tasks in an Airflow instance are executed while the KubernetesPodOperator is an operator defining that a single task is to be launched in a Kubernetes Pod with the given configuration, which does not affect any other tasks in the Airflow instance.
+The [KubernetesExecutor](https://airflow.apache.org/docs/apache-airflow/stable/executor/kubernetes.html) and the KubernetesPodOperator both dynamically launch and terminate pods to run Airflow tasks. As the names suggest, KubernetesExecutor is an executor, which means it affects how all tasks in an Airflow instance are executed, while the KubernetesPodOperator is an operator defining that a single task is to be launched in a Kubernetes Pod with the given configuration and does not affect any other tasks in the Airflow instance.
 
-Compared to the KPO the KubernetesExecutor:
+Compared to the KPO, the KubernetesExecutor:
 
-- can run all existing Airflow tasks in a Kubernetes Pod without needing to build a Docker image.
-- is set at the configuration level of the Airflow instance, which means _all_ tasks will each be run in their own Kubernetes Pod, which may be desired in some use cases to leverage auto-scaling but not ideal if many small tasks are run that would not need their own Pod to be started.
-- has less abstraction over Pod configuration. All configurations have to be passed in as a dictionary via the argument `executor_config`.
+- Runs Airflow tasks in a Kubernetes pod without needing to build a Docker image.
+- Is implemented at the configuration level of the Airflow instance, which means _all_ tasks will each be run in their own Kubernetes pod. This may be desired in some use cases to leverage auto-scaling, but is generally not ideal for environments with a high volume of shorter running tasks.
+- Has less abstraction over pod configuration. All task-level configurations have to be passed in as a dictionary via the `BaseOperator` argument `executor_config`.
 - creates a new field in the view of individual task instances in the Airflow UI `K8s Pod Spec` which shows the specifications of the Pod that was run.
-- if a custom Docker image is passed to the KubernetesExecutor it needs to have Airflow installed, otherwise the task will not run. This is not the case with the KPO, which can run any valid Docker image.
+- If a custom Docker image is passed to the KubernetesExecutor, it needs to have Airflow installed, otherwise the task will not run. This is not the case with the KPO, which can run any valid Docker image.
 
-Both the KubernetesPodOperator and the KubernetesExecutor can use the entire Kubernetes API with regards to Pod creation, which means every task can be fulfilled with either option and which one to use is an individual choice based on the user's requirements and preferences. You can think of the KPO as "Docker Image first" and the KubernetesExecutor as "Operator first" implementations.
+Both the KubernetesPodOperator and the KubernetesExecutor can use the entire Kubernetes API with regards to pod creation. Which one to use is an individual choice based on the user's requirements and preferences. You can think of the KPO as "Docker image first" and the KubernetesExecutor as "operator first" implementations. The KPO is generally ideal for controlling the environment the task is run in, while the KubernetesExecutor is ideal for controlling resource optimization.
 
 ## How to configure the KubernetesPodOperator
 
-In this section we will list some of the parameters of the KubernetesPodOperator, for concrete use cases see the section 'When to use the KPO' earlier in this guide. The KPO launches any valid Docker Image provided to it (`image`) in a new Kubernetes Pod on an existing Kubernetes cluster. The many other parameters available to the user are all specifications of the Pod configuration which the KPO translates into a call to the [Kubernetes API](https://kubernetes.io/docs/reference/kubernetes-api/). The KubernetesPodOperator offers full access to Kubernetes API functionality relating to Pod creation.    
+The KPO launches any valid Docker Image provided to it (passed via the `image` parameter) in a new Kubernetes pod on an existing Kubernetes cluster. The operator has many other parameters which specify the pod configuration which the KPO translates into a call to the [Kubernetes API](https://kubernetes.io/docs/reference/kubernetes-api/). The KubernetesPodOperator offers full access to Kubernetes API functionality relating to pod creation.    
 
-The KubernetesPodOperator can be instantiated like any other Operator within the context of a DAG. It can run with only a few arguments being mandatory. In fact the KPO will run a new Pod in the same cluster with only the following arguments supplied:
+The KubernetesPodOperator can be instantiated like any other operator within the context of a DAG. The following are some of the arguments that can be passed to the operator.
+
+**Mandatory arguments** are:
 
 - `task_id`: a unique string identifying the task within Airflow.
 - `namespace`: the namespace within your Kubernetes cluster the new Pod should be assigned to.
 - `name`: the name of the Pod created. This name needs to be unique for each Pod within a namespace.
 - `image`: a Docker image to launch. Images from [hub.docker.com](https://hub.docker.com/) can be passed in with just the image name, custom repositories have to be given as full URLs.
 
-Of course the Pod created can be configured further, some of the most commonly used arguments are:
+Commonly used **optional arguments** include:
 
 - `random_name_suffix`: generates a random suffix for the Pod name if set to `True`. Avoids naming conflicts when running a large number of Pods.
 - `labels`: add key:value pairs to the Pod which can be used to logically group decoupled objects together.
@@ -88,9 +90,9 @@ Of course the Pod created can be configured further, some of the most commonly u
 - `get_logs`: provides the `stdout` of the container as task-logs to the Airflow logging system.
 - `log_events_on_failure`: if set to `True` events will be logged in case the Pod fails (default: `False`).
 
-As shown in 'Example: Spinning up a Pod in EKS from Airflow' below, you can define an entrypoint (`cmds`) and its arguments (`arguments`) for your container, these two fields can be used with Jinja templates.
+There are also many other arguments that can be used to configure the pod and pass information to the Docker image. For example, the 'Spinning up a Pod in EKS from Airflow' section below shows how to define an entrypoint (`cmds`) and its arguments (`arguments`) for your container.
 
-> **Note**: The following KPO arguments can be used with Jinja templates: image, cmds, arguments, env_vars, labels, config_file, Pod_template_file and namespace.
+> **Note**: The following KPO arguments can be used with Jinja templates: `image`, `cmds`, `arguments`, `env_vars`, `labels`, `config_file`, `Pod_template_file`, and `namespace`.
 
 To specify environment variables for a Pod it is possible to use the argument `env_vars` for individual variables or pass in a [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/) via `volumes`.
 
@@ -114,9 +116,9 @@ The KubernetesPodOperator uses the [Kubernetes Hook](https://registry.astronomer
 
 The `kubernetes_conn_id` is the preferred way of setting up your Kubernetes connection. `in_cluster`, `cluster_context` and the path to the `config_file` can be set within your connection and overwritten by using the parameters in the KPO. Setting these parameters at the level of `airflow.cfg` has been deprecated.
 
-### Example: Using the KubernetesPodOperator to run a script in Haskell
+### Example: Using the KPO to Run a Script in Another Language
 
-A frequent use case for the KubernetesPodOperator is to run scripts for tasks better described in a language other than Python. For this purpose a custom Docker image has to be build and either run from either a public or private [DockerHub repository](https://docs.docker.com/docker-hub/repos/).
+A frequent use case for the KubernetesPodOperator is to run scripts for tasks better described in a language other than Python. For this purpose a custom Docker image has to be built and either run from either a public or private [DockerHub repository](https://docs.docker.com/docker-hub/repos/).
 
 > **Note**: Astro provides documentation on [how to run images from private repositories](https://docs.astronomer.io/astro/kubernetesPodoperator).
 
@@ -130,7 +132,7 @@ main = do
         putStrLn ("Hello, " ++ name)
 ```
 
-The Dockerfile uses `cabal` as a system for building and packaging Haskell programs, for this example the `haskell_example.cabal` file built automatically when running `cabal init` in a directory named `haskell_example` is sufficient.
+The Dockerfile creates the necessary environment to run the script and then executes it with a `CMD` command.
 
 ```Dockerfile
 FROM haskell
@@ -143,7 +145,7 @@ RUN cabal install
 CMD ["haskell_example"]
 ```
 
-After making the Docker image available it is possible to launch it from the KPO via the `image` argument. The example DAG below showcases a variety of arguments of the KubernetesPodOperator including how to pass the environment variable `NAME_TO_GREET` which is used from within the Haskell code.
+After making the Docker image available it can be run from the KPO via the `image` argument. The example DAG below showcases a variety of arguments of the KubernetesPodOperator, including how to pass the environment variable `NAME_TO_GREET` which is used from within the Haskell code.
 
 ```python
 from airflow import DAG
@@ -214,11 +216,11 @@ Some advice on where to store the images such that they can be retrieved on Astr
 
 ## Example: Using the KubernetesPodOperator with XComs
 
-[XComs](https://airflow.apache.org/docs/apache-airflow/stable/concepts/xcoms.html) is a commonly used way to pass small amounts of data between tasks. It is possible to use this feature with the KPO both for it to receive values stored in XCom and push values to XComs itself.
+[XCom](https://airflow.apache.org/docs/apache-airflow/stable/concepts/xcoms.html) is a commonly used Airflow feature for passing small amounts of data between tasks. It is possible to use this feature with the KPO to both receive values stored in XCom and push values to XCom.
 
-The DAG below shows a straightforward ETL pipeline with an `extract_data` task simulating running a query on a database and returning one value that by being returned from the Python function is automatically pushed to XComs thanks to the [TaskFlow API](https://airflow.apache.org/docs/apache-airflow/stable/tutorial_taskflow_api.html#tutorial-on-the-taskflow-api).  
+The DAG below shows a straightforward ETL pipeline with an `extract_data` task that runs a query on a database and returns a value; the return value is automatically pushed to XComs thanks to the [TaskFlow API](https://airflow.apache.org/docs/apache-airflow/stable/tutorial_taskflow_api.html#tutorial-on-the-taskflow-api).  
 
-The `transform` task is a KubernetesPodOperator which launches an image having been built with the following Dockerfile:
+The `transform` task is a KubernetesPodOperator which requires the XCom data pushed from the upstream task before it, and launches an image having been built with the following Dockerfile:
 
 ```dockerfile
 FROM python
@@ -233,7 +235,7 @@ COPY multiply_by_23.py ./
 CMD ["python", "./multiply_by_23.py"]
 ```
 
-It is very important to make sure to create the file `airflow/xcom/return.json` because Airflow will only look for XComs to pull at that specific location. The image also contains a simple Python script to multiply an environment variable by 23, package the result into a json and write that json to the correct file to be retrieved as an XCom.
+When using XComs with the KPO, it is very important to create the file `airflow/xcom/return.json`, because Airflow will only look for XComs to pull at that specific location. The image also contains a simple Python script to multiply an environment variable by 23, package the result into a json and write that json to the correct file to be retrieved as an XCom.
 
 ```python
 import os
@@ -309,13 +311,13 @@ with DAG(
     extract_data() >> transform >> load_data()
 ```
 
-## Example: Spinning up a Pod in EKS from Airflow
+## Example: Using KPO to Run a Pod in a Separate Cluster
 
-If some of your tasks require specific resources like a GPU you may want to run them in a different cluster than your Airflow Instance. In setups where both clusters are used by the same AWS or GCP account this can be managed with roles and permissions. There is also the possibility to use a CI account and enable [cross-account access to AWS EKS cluster resources](https://aws.amazon.com/blogs/containers/enabling-cross-account-access-to-amazon-eks-cluster-resources/).  
+If some of your tasks require specific resources like a GPU you may want to run them in a different cluster than your Airflow Instance. In setups where both clusters are used by the same AWS or GCP account, this can be managed with roles and permissions. There is also the possibility to use a CI account and enable [cross-account access to AWS EKS cluster resources](https://aws.amazon.com/blogs/containers/enabling-cross-account-access-to-amazon-eks-cluster-resources/).  
 
-However you may want to use a specific AWS or GCP account that you keep separate from your Airflow environment. Or you are currently running Airflow on a local setup not using Kubernetes but still want to run some tasks in a Kubernetes Pod on a remote cluster, these are possible use cases for this example.
+However, you may want to use a specific AWS or GCP account that you keep separate from your Airflow environment. Or you are currently running Airflow on a local setup not using Kubernetes, but still want to run some tasks in a Kubernetes pod on a remote cluster.
 
-The example below shows the steps to take to set up an EKS cluster on AWS and run a Pod on it from an Airflow instance if cross-account access is not feasible. After setup of the EKS cluster the `KubeConfig` as well as the `AWS Profile` have to be provided to Airflow to make the connection to the remote cluster.  
+The example below shows the steps to take to set up an EKS cluster on AWS and run a pod on it from an Airflow instance where cross-account access is not feasible. After setup of the EKS cluster, the `KubeConfig` as well as the `AWS Profile` have to be provided to Airflow to make the connection to the remote cluster. Note that the same general steps are applicable to other Kubernetes services (e.g. GKE).  
 
 > **Note**: If you are using [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/) consider using [GKEStartPodOperator](https://registry.astronomer.io/providers/google/modules/gkestartPodoperator).
 
@@ -364,7 +366,7 @@ Make a copy of `~/.aws` available to your Airflow environment (for Astro users: 
 
 Lastly, create a new EKS cluster (**EKS** -> **Clusters** -> **Add cluster**) and assign the the newly created role to it. The cluster might take a few minutes to become active.
 
-### Step 2 Retrieve the KubeConfig file from the EKS cluster
+### Step 2: Retrieve the KubeConfig file from the EKS cluster
 
 To be able to remotely connect to the newly created EKS cluster the `KubeConfig` file is needed. It can be retrieved by running:
 
@@ -408,11 +410,11 @@ users:
       provideClusterInfo: false
 ```
 
-The `KubeConfig` file is how the KPO will connect to a Kubernetes cluster by running the awscli with the default profile, using the credentials you provided in step 1.
+The `KubeConfig` file is how the KPO will connect to a Kubernetes cluster by running the `awscli` with the default profile, using the credentials you provided in Step 1.
 
 ### Step 3 Add a namespace and service account to the EKS Cluster
 
-It is best practice to use a new namespace for all Pods sent to the EKS cluster from the Airflow environment and a separate service account.  
+It is best practice to use a new namespace and separate service account for all pods sent to the EKS cluster from the Airflow environment.  
 
 ```bash
 # create a new namespace on the EKS cluster
@@ -424,18 +426,18 @@ kubectl create namespace <your namespace name>
 kubectl create serviceaccount <service account name> -n <your namespace name>
 ```
 
-### Step 4 Adjust Airflow configuration files
+### Step 4: Adjust the Airflow configuration files
 
-This step will differ depending on the Airflow setup. When running Airflow locally it is just necessary to make sure `awscli`, `apache-airflow-providers-cncf-kubernetes`,
+This step will differ depending on the Airflow setup. When running Airflow locally, it is necessary to make sure `awscli`, `apache-airflow-providers-cncf-kubernetes`,
 and `apache-airflow-providers-amazon` are installed correctly on the local machine.
 
-For dockerized settings add the following line to your Dockerfile to copy your aws credentials from `/include` (or any other location) into the container:
+If you are running Airflow with Docker, add the following line to your Dockerfile to copy your aws credentials from `/include` (or any other location) into the container:
 
 ```dockerfile
 COPY --chown=astro:astro include/.aws /home/astro/.aws
 ```
 
-To be able to correctly authenticate yourself to the remote cluster it is also important to add the AWS command line tool (`awscli`) to your `packages.txt`, and the necessary provider packages to `requirements.txt` (these will differ depending on what cloud you are connecting to):
+To be able to correctly authenticate yourself to the remote cluster it is also important to add the AWS command line tool (`awscli`) to your `packages.txt`, and the necessary provider packages to `requirements.txt` (the provider packages will differ depending on what cloud you are connecting to):
 
 ```text
 awscli
@@ -446,13 +448,13 @@ apache-airflow-providers-cncf-kubernetes
 apache-airflow-providers-amazon
 ```
 
-### Step 5 Add AWS connection ID
+### Step 5: Add AWS connection ID
 
-In the Airflow UI navigate to **Admin** -> **Connections** to set up the connection to the AWS account running the EKS. Chose a unique connection ID and use your `aws_access_key_id` as login and your `aws_secret_access_key` as password.
+In the Airflow UI navigate to **Admin** -> **Connections** to set up the connection to the AWS account running the target EKS cluster. Chose a unique connection ID and use your `aws_access_key_id` as login and your `aws_secret_access_key` as password.
 
 ![Adding AWS connection](https://assets2.astronomer.io/main/guides/your-guide-folder/aws_connection.png)
 
-### Step 6 Add the DAG interacting with EKS  
+### Step 6: Create the DAG with the KPO 
 
 If dynamic behavior of the EKS cluster is desired, e.g. Nodes get created with specifications for a task and deleted after the task has run, it is necessary to use several classes from the Amazon provider package as shown in the example DAG below. If your remote Kubernetes cluster has Nodes already available you will only need the KubernetesPodOperator itself (task number 3 in the example).
 

--- a/guides/kubepod-operator.md
+++ b/guides/kubepod-operator.md
@@ -113,7 +113,7 @@ The `kubernetes_conn_id` is the preferred way of setting up your Kubernetes conn
 
 ### Example: Using KubernetesPodOperator to run a script in Haskell
 
-A frequent use case for the KubernetesPodOperator is to run scripts in languages other than Python. For this purpose a custom Docker Image has to be build and either run a public or private [DockerHub repository]((https://docs.docker.com/docker-hub/repos/).
+A frequent use case for the KubernetesPodOperator is to run scripts in languages other than Python. For this purpose a custom Docker Image has to be build and either run a public or private [DockerHub repository](https://docs.docker.com/docker-hub/repos/).
 
 > **Note**: Astro provides documentation on [how to run images from private repositories](https://docs.astronomer.io/astro/kubernetespodoperator).
 
@@ -553,14 +553,4 @@ with DAG(
     # setting the dependencies
     create_gpu_nodegroup >> check_nodegroup_status >> run_on_EKS
     run_on_EKS >> delete_gpu_nodegroup >> check_nodegroup_termination
-```
-
-troubleshoot KPO  
-added
-```
-      - --profile
-      - default
-      command: aws
-      interactiveMode: IfAvailable
-      provideClusterInfo: false
 ```

--- a/guides/kubepod-operator.md
+++ b/guides/kubepod-operator.md
@@ -9,22 +9,22 @@ tags: ["Kubernetes", "Operators"]
 
 ## Overview
 
-The [`KubernetesPodOperator`](https://registry.astronomer.io/providers/kubernetes/modules/kubernetesPodoperator) (KPO) runs Airflow tasks in a Kubernetes Pod. By abstracting calls to the Kubernetes API, the KPO enables you to start and run Pods from Airflow using DAG code.
+The [KubernetesPodOperator](https://registry.astronomer.io/providers/kubernetes/modules/kubernetesPodoperator) (KPO) runs a Docker image in a Kubernetes Pod as an Airflow task. By abstracting calls to the Kubernetes API, the KubernetesPodOperator enables you to start and run Pods from Airflow using DAG code.
 
 In this guide, we cover:
 
-- The requirements for running the `KubernetesPodOperator`.
-- When to use the `KubernetesPodOperator`.
-- How to configure the `KubernetesPodOperator`.
-- The differences between the `KubernetesPodOperator` and the Kubernetes executor.
+- The requirements for running the KubernetesPodOperator.
+- When to use the KubernetesPodOperator.
+- How to configure the KubernetesPodOperator.
+- The differences between the KubernetesPodOperator and the Kubernetes executor.
 
-We also provide examples of how to use the KPO to run a task in a language other than Python, how to use the KPO with XComs, and how to launch a Pod in a remote AWS EKS Cluster.  
+We also provide examples of how to use the KubernetesPodOperator to run a task in a language other than Python, how to use the KubernetesPodOperator with XComs, and how to launch a Pod in a remote AWS EKS Cluster.  
 
 > **Note**: Kubernetes is a powerful tool for container orchestration with complex functionality. If you are unfamiliar with Kubernetes we recommend starting with the [Kubernetes Documentation](https://kubernetes.io/docs/home/).  
 
 ## Requirements For Using the KubernetesPodOperator
 
-To use the `KubernetesPodOperator` you first need install the Kubernetes provider package. To install it with pip, run:
+To use the KubernetesPodOperator you first need to install the Kubernetes provider package. To install it with pip, run:
 
 ```bash
 pip install apache-airflow-providers-cncf-kubernetes==<version>
@@ -34,7 +34,8 @@ Make sure you install the right version of the provider package for your version
 
 You also need an existing Kubernetes cluster to connect to. This is commonly the same cluster that Airflow is running on, but it doesn't have to be.
 
-You don't need to use the Kubernetes executor to use the KPO. You can use any of the following executors:
+You don't need to use the Kubernetes executor to use the KubernetesPodOperator. You can use any of the following executors:
+
 - Local executor
 - LocalKubernetes executor
 - Celery executor
@@ -43,11 +44,11 @@ You don't need to use the Kubernetes executor to use the KPO. You can use any of
 
 When using Celery, remember to install its [provider](https://registry.astronomer.io/providers/celery).
 
-> **Note**: On Astro, all clusters come pre-built with the infrastructure needed to run the KPO with the Celery executor.  For more information, see the [KPO documentation on Astro](https://docs.astronomer.io/astro/kubernetespodoperator).  
+> **Note**: On Astro, all clusters come pre-built with the infrastructure needed to run the KubernetesPodOperator with the Celery executor.  For more information, see the [KubernetesPodOperator documentation on Astro](https://docs.astronomer.io/astro/kubernetespodoperator).  
 
 ### Running the KubernetesPodOperator Locally
 
-Setting up your local environment to use the KPO can help you avoid tedious deploys to remote environments. This can be accomplished in several ways.
+Setting up your local environment to use the KubernetesPodOperator can help you avoid tedious deploys to remote environments. This can be accomplished in several ways.
 
 If you use the Astro CLI, follow the [Astro docs](https://docs.astronomer.io/astro/kubepodoperator-local) to set up your local environment. The steps in these docs can be adapted for other dockerized Airflow setups.
 
@@ -56,9 +57,9 @@ It is also possible to run open source Airflow within a local Kubernetes cluster
 
 ## When to use the KubernetesPodOperator
 
-The `KubernetesPodOperator` runs any Docker image provided to it. Frequent use cases are:
+The KubernetesPodOperator runs any Docker image provided to it. Frequent use cases are:
 
-- Running a task in a language other than Python. We include an example of how to run a Haskell script with the `KubernetesPodOperator` to run a script in Haskell' later in this guide.
+- Running a task in a language other than Python. We include an example of how to run a Haskell script with the KubernetesPodOperator later in this guide.
 - Having full control over how much compute resources and memory a single task can use.
 - Executing tasks in a separate environment with individual packages and dependencies.
 - Running tasks that use a version of Python not supported by your Airflow environment.
@@ -67,26 +68,26 @@ The `KubernetesPodOperator` runs any Docker image provided to it. Frequent use c
 Sometimes you may want to run Pods on different clusters, for example if only some need GPU resources while others do not. An example of this is provided at the end of the guide.
 
 
-### KubernetesPodOperator vs KubernetesExecutor
+### KubernetesPodOperator vs Kubernetes executor
 
 In Airflow you have the option to choose between a variety of [executors](https://www.astronomer.io/guides/airflow-executors-explained) which determine how your Airflow tasks will be executed.
 
-The Kubernetes executor and the `KubernetesPodOperator` both dynamically launch and terminate Pods to run Airflow tasks. As the name suggests, the Kubernetes executor affects how all tasks in an Airflow instance are executed. The `KubernetesPodOperator` launches only its own task in a Kubernetes Pod with its own configuration. It does not affect any other tasks in the Airflow instance. Details on how to configure the Kubernetes executor can be found in the [Airflow Documentation](https://airflow.apache.org/docs/apache-airflow/stable/executor/kubernetes.html).
+The Kubernetes executor and the KubernetesPodOperator both dynamically launch and terminate Pods to run Airflow tasks. As the name suggests, the Kubernetes executor affects how all tasks in an Airflow instance are executed. The KubernetesPodOperator launches only its own task in a Kubernetes Pod with its own configuration. It does not affect any other tasks in the Airflow instance. Details on how to configure the Kubernetes executor can be found in the [Airflow Documentation](https://airflow.apache.org/docs/apache-airflow/stable/executor/kubernetes.html).
 
-Compared to the KPO, the `KubernetesExecutor`:
+The main differences between the KubernetesPodOperator and the Kubernetes executor are:
 
-- Runs Airflow tasks in a Kubernetes Pod without the user needing to specify a Docker image.
-- Is implemented at the configuration level of the Airflow instance, which means _all_ tasks will each be run in their own Kubernetes Pod. This may be desired in some use cases to leverage auto-scaling, but is generally not ideal for environments with a high volume of shorter running tasks.
-- Has less abstraction over Pod configuration. All task-level configurations have to be passed in as a dictionary via the `BaseOperator` argument `executor_config`, which is available to all operators.
-- If a custom Docker image is passed to the `KubernetesExecutor`'s `base` container by providing it to either the `pod_template_file` or the `pod_override` key in the dictionary for the `executor_config` argument, it needs to have Airflow installed, otherwise the task will not run. A possible reason for customizing this Docker image would be to run a task in an environment with different versions of packages than the majority of the tasks an Airflow instance. This is not the case with the KPO, which can run any valid Docker image.
+- The Kubernetes executor runs a task defined in Airflow using any existing operator in a Kubernetes Pod without the user needing to specify a Docker image, while the KubernetesPodOperator requires a Docker image to be specified.
+- The KubernetesPodOperator defines one isolated Airflow task. In contrast the Kubernetes executor is implemented at the configuration level of the Airflow instance, which means _all_ tasks will each be run in their own Kubernetes Pod. This may be desired in some use cases to leverage auto-scaling, but is generally not ideal for environments with a high volume of shorter running tasks.
+- In comparison to the KubernetesPodOperator the Kubernetes executor has less abstraction over Pod configuration. All task-level configurations have to be passed in as a dictionary via the `BaseOperator` argument `executor_config`, which is available to all operators.
+- If a custom Docker image is passed to the Kubernetes executor's `base` container by providing it to either the `pod_template_file` or the `pod_override` key in the dictionary for the `executor_config` argument, it needs to have Airflow installed, otherwise the task will not run. A possible reason for customizing this Docker image would be to run a task in an environment with different versions of packages than the majority of the tasks an Airflow instance. This is not the case with the KubernetesPodOperator, which can run any valid Docker image.
 
-Both the `KubernetesPodOperator` and the Kubernetes executor can use the Kubernetes API to create Pods for running tasks. Which one you should use is based on the your requirements and preferences. The KPO is generally ideal for controlling the environment the task is run in, while the Kubernetes executor is ideal for controlling resource optimization. It's common to use both the Kubernetes executor and the  KPO in the same Airflow environment, where all tasks need to run on Kubernetes but only some tasks need the KPO's fine-grained resource configurations.
+Both the KubernetesPodOperator and the Kubernetes executor can use the Kubernetes API to create Pods for running tasks. Which one you should use is based on your requirements and preferences. The KubernetesPodOperator is generally ideal for controlling the environment the task is run in, while the Kubernetes executor is ideal for controlling resource optimization. It's common to use both the Kubernetes executor and the KubernetesPodOperator in the same Airflow environment, where all tasks need to run on Kubernetes but only some tasks need the KubernetesPodOperator's fine-grained environment configurations.
 
-## How to configure the `KubernetesPodOperator`
+## How to configure the KubernetesPodOperator
 
-The KPO launches any valid Docker image provided to it in a new Kubernetes Pod on a Kubernetes cluster. The `KubernetesPodOperator` includes supports arguments for some of the most common Pod settings, but you can also directly access Kubernetes API for detailed pod configuration.
+The KubernetesPodOperator launches any valid Docker image provided to it in a new Kubernetes Pod on a Kubernetes cluster. The KubernetesPodOperator supports arguments for some of the most common Pod settings, but you can also create a Pod from a YAML file or from Python objects if you need more detailed Pod configuration.
 
-The `KubernetesPodOperator` can be instantiated like any other operator within the context of a DAG. The following are some of the arguments that can be passed to the operator.
+The KubernetesPodOperator can be instantiated like any other operator within the context of a DAG. The following are some of the arguments that can be passed to the operator.
 
 ### Required arguments
 
@@ -97,29 +98,31 @@ The `KubernetesPodOperator` can be instantiated like any other operator within t
 
 ### Optional arguments
 
-- `random_name_suffix`: generates a random suffix for the Pod name if set to `True`. Avoids naming conflicts when running a large number of Pods.
-- `labels`: add key:value pairs to the Pod which can be used to logically group decoupled objects together.
-- `ports`: provides the possibility to override default ports for the Pod.
-- `reattach_on_restart`: defines how to handle losing the worker while the Pod is running, by default (`True`) the existing Pod will reattach to the worker on the next try. `False` creates a new Pod for each try.
+- `random_name_suffix`: Generates a random suffix for the Pod name if set to `True`. Avoids naming conflicts when running a large number of Pods.
+- `labels`: Add key:value pairs to the Pod which can be used to logically group decoupled objects together.
+- `ports`: Provides the possibility to override default ports for the Pod.
+- `reattach_on_restart`: Defines how to handle losing the worker while the Pod is running, by default (`True`) the existing Pod will reattach to the worker on the next try. `False` creates a new Pod for each try.
 - `is_delete_operator_pod`: `True` by default, will delete the Pod when it reaches its final state or when the execution is interrupted.
-- `get_logs`: provides the `stdout` of the container as task-logs to the Airflow logging system.
+- `get_logs`: Provides the `stdout` of the container as task-logs to the Airflow logging system.
 - `log_events_on_failure`: if set to `True` events will be logged in case the Pod fails (default: `False`).
-- `env_vars`: allows the user to specify individual environment variables for a Pod.
-- `resources`: allows the user to pass a dictionary with resource requests (keys: `request_memory`, `request_cpu`) and limits (keys: `limit_memory`, `limit_cpu`, `limit_gpu`). See the [Kubernetes Documentation on Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for more information.
-- `volumes`: can be used to pass in a modified `k8s.V1Volume`, see also the [Kubernetes example DAG from the Airflow documentation](https://airflow.apache.org/docs/apache-airflow-providers-cncf-kubernetes/stable/_modules/tests/system/providers/cncf/kubernetes/example_kubernetes.html).
+- `env_vars`: Allows the user to specify individual environment variables for a Pod.
+- `resources`: Allows the user to pass a dictionary with resource requests (keys: `request_memory`, `request_cpu`) and limits (keys: `limit_memory`, `limit_cpu`, `limit_gpu`). See the [Kubernetes Documentation on Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for more information.
+- `volumes`: Can be used to pass in a modified `k8s.V1Volume`, see also the [Kubernetes example DAG from the Airflow documentation](https://airflow.apache.org/docs/apache-airflow-providers-cncf-kubernetes/stable/_modules/tests/system/providers/cncf/kubernetes/example_kubernetes.html).
 - `affinity` and `tolerations` are ways to further specify rules for [Pod to Node assignment](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/). Like the `volumes` parameter they also require their input as a `k8s` object.
+- `pod_template_file`: Provides a way to specify the path to a YAML file defining Pod configurations.
+- `full_pod_spec`: Allows the user to specify Pod configurations using Python `k8s` objects.
 
 There are also many other arguments that can be used to configure the Pod and pass information to the Docker image. For example, the 'Spinning up a Pod in EKS from Airflow' section below shows how to define an entrypoint (`cmds`) and its arguments (`arguments`) for your container.
 
-> **Note**: The following KPO arguments can be used with Jinja templates: `image`, `cmds`, `arguments`, `env_vars`, `labels`, `config_file`, `pod_template_file`, and `namespace`.
+> **Note**: The following KubernetesPodOperator arguments can be used with Jinja templates: `image`, `cmds`, `arguments`, `env_vars`, `labels`, `config_file`, `pod_template_file`, and `namespace`.
 
-> **Note**: The `KubernetesPodOperator` includes many more possible arguments than what we list here. For a complete and up to date list see the [`KubernetesPodOperator` source code](https://github.com/apache/airflow/blob/main/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py).
+> **Note**: The KubernetesPodOperator includes more possible arguments than what we list here. For a complete and up to date list see the [KubernetesPodOperator source code](https://github.com/apache/airflow/blob/main/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py).
 
 ### Configure a Kubernetes connection
 
-If you leave `in_cluster=True`, you only need to specify the KPO's `namespace` argument to establish a connection with your Kubernetes cluster. The Pod specified by the `KubernetesPodOperator` runs on the same Kubernetes cluster as your Airflow instance is running on.
+If you leave `in_cluster=True`, you only need to specify the KubernetesPodOperator's `namespace` argument to establish a connection with your Kubernetes cluster. The Pod specified by the KubernetesPodOperator runs on the same Kubernetes cluster as your Airflow instance is running on.
 
-If you are not running Airflow on Kubernetes or want to send the Pod to a different cluster than the one currently hosting your Airflow instance, you can create a Kubernetes Cluster [connection](https://www.astronomer.io/guides/connections) which uses the [Kubernetes hook](https://registry.astronomer.io/providers/kubernetes/modules/kuberneteshook) to connect to the [Kubernetes API](https://kubernetes.io/docs/reference/kubernetes-api/) of a different Kubernetes cluster. This connection can be passed to the `KubernetesPodOperator` using the `kubernetes_conn_id` argument and needs two components to work:
+If you are not running Airflow on Kubernetes or want to send the Pod to a different cluster than the one currently hosting your Airflow instance, you can create a Kubernetes Cluster [connection](https://www.astronomer.io/guides/connections) which uses the [Kubernetes hook](https://registry.astronomer.io/providers/kubernetes/modules/kuberneteshook) to connect to the [Kubernetes API](https://kubernetes.io/docs/reference/kubernetes-api/) of a different Kubernetes cluster. This connection can be passed to the KubernetesPodOperator using the `kubernetes_conn_id` argument and needs two components to work:
 
 - A `KubeConfig` file, provided as either a path to the file or in JSON format.
 - The cluster context from the provided `KubeConfig` file.
@@ -130,9 +133,9 @@ The following image shows how to set up a Kubernetes cluster connection in the A
 
 The components of the connection can also be set or overwritten at the task level by using the arguments `config_file` (to specify the path to the `KubeConfig` file) and `cluster_context`. Setting these parameters at the level of `airflow.cfg` has been deprecated.
 
-### Example: Using the KPO to Run a Script in Another Language
+### Example: Using the KubernetesPodOperator to Run a Script in Another Language
 
-A frequent use case for the `KubernetesPodOperator` is to run scripts for tasks better described in a language other than Python. To do this, you build a custom Docker image and run it from either a public or private [DockerHub repository](https://docs.docker.com/docker-hub/repos/).
+A frequent use case for the KubernetesPodOperator is to run a Docker image containing a script for a task better described in a language other than Python in a Kubernetes Pod. To do this, you build a custom Docker image containing one or more scripts in your preferred language plus instructions on how to run these scripts and run it from either a public or private [DockerHub repository](https://docs.docker.com/docker-hub/repos/).
 
 > **Note**: Astro provides documentation on [how to run images from private repositories](https://docs.astronomer.io/astro/kubernetespodoperator).
 
@@ -159,7 +162,7 @@ RUN cabal install
 CMD ["haskell_example"]
 ```
 
-After making the Docker image available it can be run from the KPO via the `image` argument. The example DAG below showcases a variety of arguments of the `KubernetesPodOperator`, including how to pass `NAME_TO_GREET` to the Haskell code.
+After making the Docker image available it can be run from the KubernetesPodOperator via the `image` argument. The example DAG below showcases a variety of arguments of the KubernetesPodOperator, including how to pass `NAME_TO_GREET` to the Haskell code.
 
 ```python
 from airflow import DAG
@@ -219,11 +222,11 @@ with DAG(
 
 ## Example: Using the KubernetesPodOperator with XComs
 
-[XCom](https://airflow.apache.org/docs/apache-airflow/stable/concepts/xcoms.html) is a commonly used Airflow feature for passing small amounts of data between tasks. You can use the KPO to both receive values stored in XCom and push values to XCom.
+[XCom](https://airflow.apache.org/docs/apache-airflow/stable/concepts/xcoms.html) is a commonly used Airflow feature for passing small amounts of data between tasks. You can use the KubernetesPodOperator to both receive values stored in XCom and push values to XCom.
 
 The DAG below shows an ETL pipeline with an `extract_data` task that runs a query on a database and returns a value. The return value is automatically pushed to XComs thanks to the [TaskFlow API](https://airflow.apache.org/docs/apache-airflow/stable/tutorial_taskflow_api.html#tutorial-on-the-taskflow-api).  
 
-The `transform` task is a `KubernetesPodOperator` which requires the XCom data pushed from the upstream task before it, and launches an image having been built with the following Dockerfile:
+The `transform` task is a KubernetesPodOperator which requires the XCom data pushed from the upstream task before it, and launches an image having been built with the following Dockerfile:
 
 ```dockerfile
 FROM python
@@ -239,7 +242,7 @@ COPY multiply_by_23.py ./
 CMD ["python", "./multiply_by_23.py"]
 ```
 
-When using XComs with the KPO, you must create the file `airflow/xcom/return.json` in your Docker container (ideally from within your Dockerfile as seen above), because Airflow can only look for XComs to pull at that specific location. The Docker image also contains a simple Python script to multiply an environment variable by 23, package the result into JSON, and write that JSON to the correct file to be retrieved as an XCom. The XComs from the KPO are pushed only if the task itself was marked as successful.  
+When using XComs with the KubernetesPodOperator, you must create the file `airflow/xcom/return.json` in your Docker container (ideally from within your Dockerfile as seen above), because Airflow can only look for XComs to pull at that specific location. The Docker image also contains a simple Python script to multiply an environment variable by 23, package the result into JSON, and write that JSON to the correct file to be retrieved as an XCom. The XComs from the KubernetesPodOperator are pushed only if the task itself was marked as successful.  
 
 ```python
 import os
@@ -260,7 +263,7 @@ f.close()
 
 Lastly the `load_data` task pulls the XCom returned from the `transform` task and prints it to the console.
 
-Below you can find the full DAG code. Remember to only turn on `do_xcom_push` if you have created the `airflow/xcom/return.json` within the Docker container run by the KPO, otherwise the task will fail.
+Below you can find the full DAG code. Remember to only turn on `do_xcom_push` if you have created the `airflow/xcom/return.json` within the Docker container run by the KubernetesPodOperator, otherwise the task will fail.
 
 
 ```python
@@ -316,7 +319,7 @@ with DAG(
     extract_data() >> transform >> load_data()
 ```
 
-## Example: Using KPO to Run a Pod in a Separate Cluster
+## Example: Using KubernetesPodOperator to Run a Pod in a Separate Cluster
 
 If some of your tasks require specific resources like a GPU, you might want to run them in a different cluster than your Airflow Instance. In setups where both clusters are used by the same AWS or GCP account, this can be managed with roles and permissions. There is also the possibility to use a CI account and enable [cross-account access to AWS EKS cluster resources](https://aws.amazon.com/blogs/containers/enabling-cross-account-access-to-amazon-eks-cluster-resources/).  
 
@@ -328,7 +331,7 @@ This example shows how to set up an EKS cluster on AWS and run a Pod on it from 
 
 ### Step 1: Set up an EKS cluster on AWS
 
-To set up a new EKS cluster on AWS, first [create an EKS cluster IAM role](https://docs.aws.amazon.com/eks/latest/userguide/service_IAM_role.html#create-service-role) with a unique name and to the following permission policies:
+To set up a new EKS cluster on AWS, first [create an EKS cluster IAM role](https://docs.aws.amazon.com/eks/latest/userguide/service_IAM_role.html#create-service-role) with a unique name and add the following permission policies:
 
 - `AmazonEKSWorkerNodePolicy`
 - `AmazonEKS_CNI_Policy`
@@ -355,7 +358,7 @@ To set up a new EKS cluster on AWS, first [create an EKS cluster IAM role](https
 }
 ```
 
-Add the new role to your local AWS credentials file, which by default is located at `~/.aws/config`.
+Add the new role to your local AWS config file, which by default is located at `~/.aws/config` (for more information see the [AWS docs](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-where)).
 
 ```text
 [default]
@@ -366,9 +369,9 @@ role_arn = <EKS role arn>
 source_profile = <your user>
 ```
 
-Make sure your default credentials include a valid and active key for your username (see the [AWS docs](https://docs.aws.amazon.com/kms/latest/developerguide/create-keys.html) for more information).
+Make sure your default credentials include a valid and active key for your username (see the [AWS docs](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys) for more information).
 
-Make a copy of `~/.aws/credentials` available to your Airflow environment. If you run Airflow using the Astro CLI, copy this file into the `include` folder of your Astro project.
+Make a copy of `~/.aws/credentials` and `~/.aws/config` available to your Airflow environment. If you run Airflow using the Astro CLI, create a new directory called `.aws` in the `include` folder of your Astro project and copy both files into it.
 
 Lastly, [create a new EKS cluster](https://docs.aws.amazon.com/eks/latest/userguide/create-cluster.html) and assign the the newly created role to it.
 
@@ -420,9 +423,9 @@ users:
 
 Once you confirm that the `KubeConfig` file is formatted properly, make it available to Airflow. If you're an Astro CLI user, you can do this by adding the file to the `include` directory of your Astro project.
 
-### Step 3: Add a namespace and service account to the EKS Cluster
+### Step 3: Add a new namespace to the EKS Cluster
 
-It is best practice to use a new namespace for the Pods that Airflow spins up in your cluster. To create a namespace or your Pods, access the EKS cluster and run:  
+It is best practice to use a new namespace for the Pods that Airflow spins up in your cluster. To create a namespace for your Pods, access the EKS cluster and run:  
 
 ```bash
 # create a new namespace on the EKS cluster
@@ -439,7 +442,7 @@ To access your cluster from local instance of Apache Airflow, install `awscli`, 
 
 #### Airflow on Docker with the Astro CLI
 
-To access the cluster from Airflow using the Astro CLI, add the following line to your Dockerfile to copy your AWS credentials from into the container:
+To access the cluster from Airflow using the Astro CLI, add the following line to your Dockerfile to copy your `config` and `credentials` file from `/include/.aws` into the container:
 
 ```dockerfile
 COPY --chown=astro:astro include/.aws /home/astro/.aws
@@ -461,22 +464,23 @@ apache-airflow-providers-amazon
 ### Step 5: Add AWS connection ID
 
 In the Airflow UI, go to **Admin** -> **Connections** to set up the connection to the AWS account running the target EKS cluster. Set the following configurations for the connection:
+
 - **Connection ID**: Any
 - **Connection Type**: Amazon Web Services
 - **Login**: Your AWS access key ID
 - **Password**: Your AWS secret access key
 
-### Step 6: Create the DAG with the KPO
+### Step 6: Create the DAG with the KubernetesPodOperator
 
-> **Note**: When creating new deployments, users of the Astro cloud will need to set one additional argument in the KPO: `labels={"airflow_kpo_in_cluster": "False"}` to connect to a remote cluster. If you are trying to set up the KPO connecting to a remote cluster in an existing deployment please contact Customer Support.
+> **Note**: When creating new deployments, users of the Astro cloud will need to set one additional argument in the KubernetesPodOperator: `labels={"airflow_kpo_in_cluster": "False"}` to connect to a remote cluster. If you are trying to set up the KubernetesPodOperator connecting to a remote cluster in an existing deployment please contact Customer Support.
 
-The following DAG utilizes several classes from the Amazon provider package to dynamically spin up and delete Pods for each task in a newly created node group. If your remote Kubernetes cluster already has a node group available, you only need to define your task in the `KubernetesPodOperator` itself.
+The following DAG utilizes several classes from the Amazon provider package to dynamically spin up and delete Pods for each task in a newly created node group. If your remote Kubernetes cluster already has a node group available, you only need to define your task in the KubernetesPodOperator itself.
 
 The example DAG contains 5 consecutive tasks:
 
 - Create a node group according to the users' specifications (in the example using GPU resources).
 - Use a sensor to check that the cluster is running correctly.
-- Use the `KubernetesPodOperator` to run any valid Docker image in a Pod on the newly created node group on the remote cluster. The example DAG uses the standard `Ubuntu` image to print "hello" to the console using a `bash` command.
+- Use the KubernetesPodOperator to run any valid Docker image in a Pod on the newly created node group on the remote cluster. The example DAG uses the standard `Ubuntu` image to print "hello" to the console using a `bash` command.
 - Delete the node group.
 - Verify that the node group has been deleted.
 
@@ -486,7 +490,7 @@ from airflow import DAG
 from datetime import datetime
 from airflow.configuration import conf
 
-# import the KPO
+# import the KubernetesPodOperator
 from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import (
                                                         KubernetesPodOperator)
 
@@ -556,7 +560,7 @@ with DAG(
         region='<your region>'
     )
 
-    # task 3 the KPO running a task
+    # task 3 the KubernetesPodOperator running a task
     # here, cluster_context and the config_file are defined at the task level
     # it is of course also possible to abstract these values
     # in a Kubernetes Cluster Connection

--- a/guides/kubepod-operator.md
+++ b/guides/kubepod-operator.md
@@ -6,30 +6,409 @@ slug: "kubepod-operator"
 heroImagePath: null
 tags: ["Kubernetes", "Operators"]
 ---
-<!-- markdownlint-disable-file -->
-## Kubernetes PodOperator
 
-Running the [KubernetesPodOperator](https://registry.astronomer.io/providers/kubernetes/modules/kubernetespodoperator) on Airflow 1.9
+## Overview
 
-The `KubernetesPodOperator` spins up a pod to run a Docker container in. If you are running Airflow on Kubernetes, it is preferable to do this rather than use the [DockerOperator](https://registry.astronomer.io/providers/docker/modules/dockeroperator).
+The [KubernetesPodOperator](https://registry.astronomer.io/providers/kubernetes/modules/kubernetespodoperator) (KPO) is an operator from the Kubernetes provider package designed to provide a straightforward way to execute a task in a Kubernetes Pod from your Airflow environment. In a nutshell the KPO is an abstraction over a call to the Kubernetes API to launch a pod.
 
-This tutorial is for anyone using Airflow 1.9 and would like to use the `KubernetesPodOperator` without upgrading their version of Airflow.
+In this guide we will list the requirements to run the KubernetesPodOperator, explain when to use it and cover its most important arguments, as well as the difference between the KPO and KubernetesExecutor. At the end of the guide we will provide two step-by-step examples on how to launch a pod within the same and within a different cluster.
 
-It assumes a Dockerized Airflow setup (in this case, the Astronomer Setup), but should apply to any Airflow set up.
+> **Note**: Kubernetes is a powerful tool for Container Orchestration with complex functionality. If you are unfamiliar with Kubernetes we recommend taking a look at the [Kubernetes 101 Guide](https://www.astronomer.io/guides/intro-to-kubernetes/) to get a general overview. For in-depth information check out the [Kubernetes Documentation](https://kubernetes.io/docs/home/).  
+
+> **Note**: If you are using [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/) consider using [GKEStartPodOperator](https://registry.astronomer.io/providers/google/modules/gkestartpodoperator).
+
+## Requirements to use KPO
+
+To use the KubernetesPodOperator it is necessary to install the Kubernetes provider package.
+
+```bash
+pip install apache-airflow-providers-cncf-kubernetes==<version>
+```
+
+Required versions of the `apache-airflow`, `cryptography` and `kubernetes` packages for specific versions of the Kubernetes provider package are listed in the [Airflow Documentation](https://airflow.apache.org/docs/apache-airflow-providers-cncf-kubernetes/stable/index.html#requirements).
+
+You will also need an existing Kubernetes cluster to connect to. It is _not_ necessary to use the Kubernetes Executor in order to use the KPO. You may use any of the following executors: `CeleryExecutor`, `KubernetesExecutor`, [`CeleryKubernetesExecutor`](https://airflow.apache.org/docs/apache-airflow/2.0.0/executor/celery_kubernetes.html). When using Celery remember to install its [provider](https://registry.astronomer.io/providers/celery).
+
+> **Note**: On Astro the infrastructure needed to run KPO with CeleryExecutor is pre-built into every Cluster. Astronomer provides [comprehensive documentation on using KPO on Astro](https://docs.astronomer.io/astro/kubernetespodoperator).  
+
+## When to use KPO
+
+The KubernetesPodOperator runs any Docker image provided to it, whether they are pulled from [DockerHub](https://hub.docker.com/) or from private repositories. Frequent use cases are:
+
+- Running a task better described in a language other than Python.
+- Having full control over how much compute resources and memory a single task can use.
+- Executing tasks in an separate environment with individual packages and dependencies.
+
+Sometimes you may want to run pods on different clusters, for example if only some need GPU resources while others do not. This is also possible with the KPO and a step-by-step example is provided at the end of this guide.
+
+## How to configure KPO
+
+In this section we will list some of the parameters of the KubernetesPodOperator, for concrete use cases see the two examples at the end of this guide.
+
+The KubernetesPodOperator can be instantiated like any other Operator within the context of a DAG. It can run with only a few arguments being mandatory. In fact the KPO will run a new pod in the same cluster with only the following arguments supplied:
+
+- `task_id`: a unique string identifying the task within Airflow.
+- `namespace`: the namespace within your Kubernetes cluster the new pod should be assigned to.
+- `name`: the name of the pod created. This name needs to be unique for each pod within a namespace.
+- `image`: a Docker image to launch. Images from [hub.docker.com](https://hub.docker.com/) can be passed in with just the image name, custom repositories have to be given as full URLs.
+
+Of course the pod created can be configured further, some of the most commonly used arguments are:
+
+- `random_name_suffix`: generates a random suffix for the pod name if set to `True`. Avoids naming conflicts when running a large number of pods.
+- `labels`: add key:value pairs to the pod which can be used to logically group decoupled objects together.
+- `ports`: provides the possibility to override default ports for the pod.
+- `reattach_on_restart`: defines how to handle losing the worker while the pod is running, by default (`True`) the existing pod will reattach to the worker on the next try. `False` creates a new pod for each try.
+- `is_delete_operator_pod`: `True` by default, will delete the pod when it reaches its final state or when the execution is interrupted.
+- `get_logs`: provides the `stdout` of the container as task-logs to the Airflow logging system.
+- `log_events_on_failure`: if set to `True` events will be logged in case the pod fails (default: `False`).
+
+As shown in 'Example: Spin up a pod in the same cluster' below, you can define an entrypoint (`cmds`) and its arguments (`arguments`) for your container, these two fields can be used with Jinja templates.
+
+To specify environment variables for a pod it is possible to use the argument `env_vars` for individual variables or pass in a [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/) via `volumes`.
+
+Management of distributed resources and balancing of workloads are some of the core functionalities of Kubernetes. The [Kubernetes Scheduler](https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/) on the Kubernetes Control Plane matches each pod to the best physical or virtual machine (called Node in Kubernetes) possible. When using the KPO there are multiple ways to add information configuring this process:
+
+- `resources`: allows the user to pass a dictionary with resource requests (keys: `request_memory`, `request_cpu`) and limits (keys: `limit_memory`, `limit_cpu`, `limit_gpu`). See the [Kubernetes Documentation on Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for more information.
+- `node_selectors`, `affinity` and `tolerations` are ways to further specify rules for [pod to node assignment](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/).
+
+To pass small amounts of information between tasks Airflow uses [XComs](https://airflow.apache.org/docs/apache-airflow/stable/concepts/xcoms.html). It is possible to push content from the container within a pod, specifically from the file `/airflow/xcom/return.json`, by setting the KPO argument `do_xcom_push` to `True`.
+
+> Note: Many more arguments are available to customize the KubernetesPodOperator further. For a complete and up to date list see the [KubernetesPodOperator source code](https://github.com/apache/airflow/blob/main/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py).
+
+### Configuring Kubernetes Connection
+
+The KubernetesPodOperator uses the [Kubernetes Hook](https://registry.astronomer.io/providers/kubernetes/modules/kuberneteshook) to connect to the [Kubernetes API](https://kubernetes.io/docs/reference/kubernetes-api/) of a Kubernetes cluster. The KPO has 4 parameters pertaining to the Kubernetes Connection:
+
+- `kubernetes_conn_id`: uses a [connection](https://www.astronomer.io/guides/connections) stored in the [Airflow metadata database](https://www.astronomer.io/guides/airflow-database), which can be configured in the Airflow UI under **Admin** -> **Connections**.
+- `in_cluster`: by default set to `True`, which means the new pod will be spun up in the same cluster, you are running your Airflow instance in.
+- `config_file`: The path to the Kubernetes config file. If not specified, default value is `~/.kube/config`.
+- `cluster_context`: is used to specify a context that points to a Kubernetes cluster when `in_cluster` is set to `False`. This parameter is used to select a specific cluster if several are defined within your config file.
+
+The `kubernetes_conn_id` is the preferred way of setting up your Kubernetes connection. `in_cluster`, `cluster_context` and the path to the `config_file` can be set within your connection and overwritten by using the parameters in the KPO. Setting these parameters at the level of `airflow.cfg` has been deprecated.
+
+## KPO vs KubernetesExecutor
+
+In Airflow you have the option to choose between a variety of [executors](https://www.astronomer.io/guides/airflow-executors-explained) which determine how your Airflow tasks will be executed.
+
+The [KubernetesExecutor](https://airflow.apache.org/docs/apache-airflow/stable/executor/kubernetes.html) and the KubernetesPodOperator both dynamically launch and terminate Pods to run Airflow tasks in. As the names suggest, KubernetesExecutor is an executor, which means it affects how all tasks in an Airflow instance are executed while the KubernetesPodOperator is an operator defining that a single task is to be launched in a Kubernetes pod with the given configuration, which does not affect any other tasks in the Airflow instance.
+
+Compared to the KPO the KubernetesExecutor:
+
+- is set at the configuration level of the Airflow instance, which means _all_ tasks will each be run in their own Kubernetes pod.
+- has less abstraction over pod configuration. All configurations have to be passed in as a dictionary via the argument `executor_config`.
+- creates a new field in the view of individual task instances in the Airflow UI `K8s Pod Spec` which shows the specifications of the pod that was run.
+- can only use Docker images that have Airflow installed, otherwise they will not be able to run the task. This is not the case with the KPO, which can run any valid Docker image.
+
+## KPO local development
+
+There are several ways in which the KubernetesPodOperator can be run in local development. For users of the Astro CLI there is a [step-by-step tutorial](https://docs.astronomer.io/software/kubepodoperator-local) available in the Astro Documentation, which can also be adapted for other dockerized Airflow setups.
+
+It is also possible to run Open Source Airflow within a local Kubernetes Cluster by following these steps:
+
+- Install Docker, Docker Compose, Helm, kubectl and a service to create a local Kubernetes cluster like [KinD](https://kind.sigs.k8s.io/) or [Minikube](https://minikube.sigs.k8s.io/docs/).
+- Create a local Kubernetes Cluster.
+- Download and install the [Helm Chart for Apache Airflow](https://airflow.apache.org/docs/helm-chart/stable/index.html).
+- To be able to use additional packages (e.g. Celery to use CeleryExecutor) build a custom Airflow Dockerfile.
+- Add a possibility to deploy DAGs, for example using GitSync.
+- Use kubectl to port-forward the Airflow webserver.
+
+When running Airflow in a Kubernetes cluster using the KPO operator does not require further configuration beyond leaving the setting `in_cluster` on `True` to run a new pod within the same cluster.
+
+## KPO best practices
+
+SECTION INCOMPLETE
+
+Suggestions from issues:  
+
+- CI/CD guidelines (such as you need to be pushing updates to the KPO image)
+- make sure each KPO image update has a unique tag
+Some advice on where to store the images such that they can be retrieved on Astro
+- how to best set env variables
+
+## Example: Spinning up a pod in the same cluster
+
+When Airflow is set up to run within a Kubernetes cluster, whether locally or in the cloud, using the KubernetesPodOperator is fairly simple. The parameter `in_cluster` will default to `True` and the KPO will run any pods within the same cluster and context as Airflow is already running in.
+
+The DAG below contains one task using the KPO to execute a bash command within a new pod.
+
+```python
+from airflow import DAG
+from datetime import datetime
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import (
+                                                        KubernetesPodOperator)
+from airflow.configuration import conf
+
+# import the namespace from the airflow configuration
+namespace = conf.get("kubernetes", "NAMESPACE")
+
+# instantiate the DAG
+with DAG(
+    start_date=datetime(2022,6,1),
+    catchup=False,
+    schedule_interval='@daily',
+    dag_id='a_dag_in_k8s'
+) as dag:
+
+    # instantiate the KPO
+    KPO_bash_command = KubernetesPodOperator(
+        task_id='KPO_bash_command', # task id unique within the DAG
+        namespace=namespace, # default namespace = 'default'
+        name='my_pod_1', # pod name, unique within the namespace
+        image='ubuntu', # pulling the ubuntu image from DockerHub
+        cmds=['bash', '-cx'], # entry point
+        arguments=["echo hello"], # arguments for the entry point
+        get_logs=True, # provides stdout from the container as task logs
+        is_delete_operator_pod=True # deletion of the pod after the task ends
+        )
+```
+
+## Example: Spinning up a pod in EKS from Airflow
+
+If some of your tasks require specific resources like a GPU you may want to run them in a different cluster than your Airflow Instance. In setups where both clusters are used by the same AWS or GCP account this can be managed with roles and permissions. There is also the possibility to use a CI account and enable [cross-account access to AWS EKS cluster resources](https://aws.amazon.com/blogs/containers/enabling-cross-account-access-to-amazon-eks-cluster-resources/).  
+
+The example below shows the steps to take to set up an EKS cluster on AWS and run a pod on it from an Airflow instance if cross-account access is not feasible. After setup of the EKS cluster the `KubeConfig` as well as the `AWS Profile` have to be provided to Airflow to make the connection to the remote cluster.  
+
+### Step 1: Set up an EKS cluster on AWS
+
+To set up a new EKS cluster on AWS you first need to create an IAM role with suitable permissions.
+On AWS navigate to **Identity and Access Management (IAM)** -> **Roles** -> **Create role**. Select AWS service and `EKS` from the dropdown menu as well as `EKS - Cluster`. Make sure to give the role a unique name and to add the permission policies `AmazonEKSWorkerNodePolicy` and `AmazonEC2ContainerRegistryReadOnly`.
+
+Edit the trust policy (**IAM** -> **Roles** -> role name) of this new role to include your account and necessary AWS Services:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::<aws account id>:root",
+        "Service": [
+              "ec2.amazonaws.com",
+              "eks.amazonaws.com"
+        ]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+```
+
+Add the new role to your local AWS credentials file by default found at `~/.aws/config`.
+
+```text
+[default]
+region = <your region>
+
+[profile eksClusterRole]
+role_arn = <EKS role arn>
+source_profile = <your username>
+```
+
+Make sure your credentials in `~/.aws/credentials` are using a valid and active key for your username (keys can be generated at **IAM** -> **Users** -> your user -> **Security Credentials**).
+
+Make a copy of `~/.aws` available to your Airflow environment (for Astro users: copy it into the `include` folder).
+
+Lastly, create a new EKS cluster (**EKS** -> **Clusters** -> **Add cluster**) and assign the the newly created role to it. The cluster might take a few minutes to become active.
+
+### Step 2 Retrieve the KubeConfig file from the EKS cluster
+
+To be able to remotely connect to the newly created EKS cluster the KubeConfig file is needed. It can be retrieved by running:
+
+```bash
+aws eks --region region update-kubeconfig --name cluster_name
+```
+
+The command above will copy information into your existing `KubeConfig` file at `~/.kube/config`. Select the information pertaining to your EKS cluster and make it available to your Airflow environment (for Astro users: copy it into the `include` folder). It should have the following structure:
+
+```text
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: <key>
+    server: <address of your EKS server>
+  name: <arn of your EKS server>
+contexts:
+- context:
+    cluster: <arn of your EKS server>
+    user: <arn of your EKS server>
+  name: <arn of your EKS server>
+current-context: <arn of your EKS server>
+kind: Config
+preferences: {}
+users:
+- name: <arn of your EKS server>
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1beta1
+      args:
+      - --region
+      - < your region>
+      - eks
+      - get-token
+      - --cluster-name
+      - < your cluster name>
+      command: aws
+```
+
+### Step 3 Add a namespace and service account to the EKS Cluster
+
+It is best practice to use a new namespace for all pods sent to the EKS cluster from the Airflow environment and a separate service account.  
+
+```bash
+# create a new namespace on the EKS cluster
+kubectl create namespace airflow-kpo-default
+
+# create a new service account in your namespace using the namespace of
+# your Airflow Data Plane Cluster
+kubectl create serviceaccount <your-namespace>-kpo -n airflow-kpo-default
+```
+
+### Step 4 Adjust Airflow configuration files
+
+This step will differ depending on the Airflow setup. When running Airflow locally it is just necessary to make sure `awscli`, `apache-airflow-providers-cncf-kubernetes`,
+and `apache-airflow-providers-amazon` are installed correctly on the local machine.
+
+For dockerized settings add the following line to your Dockerfile:
+
+```dockerfile
+COPY --chown=astro:astro include/.aws /home/astro/.aws
+```
+
+Next you can add the AWS command line to your `packages.txt`, and the necessary provider packages to `requirements.txt`:
+
+```text
+awscli
+```
+
+```text
+apache-airflow-providers-cncf-kubernetes
+apache-airflow-providers-amazon
+```
+
+### Step 5 Add AWS connection ID
+
+In the Airflow UI navigate to **Admin** -> **Connections** to set up the connection to the AWS account running the EKS. Chose a unique connection ID and use your `aws_access_key_id` as login and your `aws_secret_access_key` as password.
+
+### Step 6 Add the DAG interacting with EKS  
+
+If dynamic behavior of the EKS cluster is desired, e.g. nodes get created with specifications for a task and deleted after the task has run, it is necessary to use several classes from the Amazon provider package. The DAG below has 5 tasks. The first one creates a nodegroup according to the users' specifications and afterwards a sensor checks that the cluster is running correctly. The third tasks is the actual KubernetesPodOperator running any valid Docker image. Lastly the nodegroup gets deleted and the deletion gets verified.
+
+```python
+# import DAG object and utility packages
+from airflow import DAG
+from datetime import datetime
+from airflow.configuration import conf
+
+# import the KPO
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import (
+                                                        KubernetesPodOperator)
+
+# import EKS related packages from the Amazon Provider
+from airflow.providers.amazon.aws.hooks.eks import EKSHook, NodegroupStates
+from airflow.providers.amazon.aws.operators.eks import (
+                      EKSCreateNodegroupOperator, EKSDeleteNodegroupOperator)
+from airflow.providers.amazon.aws.sensors.eks import EKSNodegroupStateSensor
+
+# custom class to create a nodegroup with Nodes on EKS
+class EKSCreateNodegroupWithNodesOperator(EKSCreateNodegroupOperator):
+
+    def execute(self, context):
+        # instantiating an EKSHook on the basis of the AWS connection (Step 5)
+        eks_hook = EKSHook(
+            aws_conn_id=self.aws_conn_id,
+            region_name=self.region,
+        )
+
+        # define the node group to create
+        eks_hook.create_nodegroup(
+            clusterName=self.cluster_name,
+            nodegroupName=self.nodegroup_name,
+            subnets=self.nodegroup_subnets,
+            nodeRole=self.nodegroup_role_arn,
+            scalingConfig={
+                'minSize': 1,
+                'maxSize': 1,
+                'desiredSize': 1
+            },
+            diskSize=20,
+            instanceTypes=['g4dn.xlarge'],
+            amiType='AL2_x86_64_GPU',   # get GPU resources
+            updateConfig={
+                'maxUnavailable': 1
+            },
+        )
+
+# instantiate the DAG
+with DAG(
+    start_date=datetime(2022,6,1),
+    catchup=False,
+    schedule_interval='@daily',
+    dag_id='a_dag_in_k8s'
+) as dag:
+
+    # task 1 creates the nodegroup
+    create_gpu_nodegroup=EKSCreateNodegroupWithNodesOperator(
+        task_id='create_gpu_nodegroup',
+        cluster_name='<your cluster name>',  
+        nodegroup_name='gpu-nodes',
+        nodegroup_subnets=['<your subnet>', '<your subnet>'],
+        nodegroup_role_arn='<arn of your EKS role>',
+        aws_conn_id='<your aws conn id>',
+        region='<your region>'
+    )
+
+    # task 2 check for nodegroup status, if it is up and running
+    check_nodegroup_status=EKSNodegroupStateSensor(
+        task_id='check_nodegroup_status',
+        cluster_name='<your cluster name>',
+        nodegroup_name='gpu-nodes',
+        mode='reschedule',
+        timeout=60 * 30,
+        exponential_backoff=True,
+        aws_conn_id='<your aws conn id>',
+        region='<your region>'
+    )
+
+    # task 3 the KPO running a task
+    run_on_EKS=KubernetesPodOperator(
+        task_id="run_on_EKS",
+        cluster_context='<arn of your cluster>',
+        namespace="airflow-kpo-default",
+        name="example_pod",
+        image='ubuntu',
+        cmds=['bash', '-cx'],
+        arguments=["echo hello"],
+        get_logs=True,
+        is_delete_operator_pod=False,
+        in_cluster=False,
+        config_file='/usr/local/airflow/include/config',
+        startup_timeout_seconds=240
+    )
+
+    # task 4 deleting the nodegroup
+    delete_gpu_nodegroup=EKSDeleteNodegroupOperator(
+        task_id='delete_gpu_nodegroup',
+        cluster_name='<your cluster name>',  
+        nodegroup_name='gpu-nodes',
+        aws_conn_id='<your aws conn id>',
+        region='<your region>'
+    )
+
+    # task 5 checking that the nodegroup was deleted successfully
+    check_nodegroup_termination=EKSNodegroupStateSensor(
+        task_id='check_nodegroup_termination',
+        cluster_name='<your cluster name>',
+        nodegroup_name='gpu-nodes',
+        aws_conn_id='<your aws conn id>',
+        region='<your region>',
+        mode='reschedule',
+        timeout=60 * 30,
+        target_state=NodegroupStates.NONEXISTENT
+    )
 
 
-1. Create a Service Account.
-
-Create a service account tied to a role that allows `create`, `get` and `watch` on pods, and `get` on `pods/logs`. Note that any task could potentially take these same actions on an arbitrary pod in the same namespace, assuming it could guess a name correctly, since it cannot list.
-
-2. Fork the code found in this repository.
-
-[This repo](https://github.com/airflow-plugins/example_kubernetes_pod) contains all the necessary Kubernetes specific Airflow plugins with the right import paths.
-
-3. Set `in_cluster` to `True`.
-
-This will tell your task to look inside the cluster for the Kubernetes config. In this setup, the workers are tied to role with the right privileges in the cluster.
-
-4. Run an example.
-
-Run the Ubuntu example to ensure that everything works as expected.
+    # setting the dependencies
+    create_gpu_nodegroup >> check_nodegroup_status >> run_on_EKS
+    run_on_EKS >> delete_gpu_nodegroup >> check_nodegroup_termination
+```


### PR DESCRIPTION
Rough first draft of the structure and content. 

Comments:
- Requirements to use KPO: currently lists CeleryExecutor, KubernetesExecutor and CeleryKubernetesExecutor. I have not found examples using other executors yet with KPO but can't be sure it is not possible at this point.
- How to configure KPO: I described a variety of arguments, maybe too many. I tried to group them logically where possible and put the 4 args pertaining to connections below a subheader because I assume these are the most searched for
- Configuring Kubernetes Connection: Not 100% certain I understood this correctly but it seems like the move is towards using the Airflow connection and away from using arguments or specifying these parameters in airflow.cfg.
- KPO vs KubernetesExecutor: I found the info that K8sExecutor needs Airflow to be installed in the Dockerimage in one of Marc's blog posts. Is this still accurate? 
- KPO local development: As discussed I only give rough steps here for how to set up running Airflow on K8s locally. I do have the step-by-step for newbies (for me) list in my files so I can easily expand on that if necessary.
- KPO best practices: as discussed this section is incomplete, I listed the suggestions from the issue.
- Example: Spinning up a pod in the same cluster: I was wondering since this is pretty straight forward if we want to expand this example a bit, maybe including XCom usage? On the other hand it might be better to have a short example like this. 
- Example: Spinning up a pod in EKS from Airflow: I included all steps here, some of which might be obvious to more experienced AWS users and can be deleted. Currently I am still stuck at the nodegroup not starting, so there might be changes if there is something wrong with the steps I took. I do not know how the service account interacts with the AWS connection yet, I'll add that if/when I find out. 

Sorry for the wall of text 😅