### PR TITLE
Add decorators section to Task Groups guide

### DIFF
--- a/guides/task-groups.md
+++ b/guides/task-groups.md
@@ -57,9 +57,9 @@ In the Airflow UI, Task Groups look like tasks with blue shading. When we expand
 
 ## Using the Task Group Decorator
 
-Another way of defining Task Groups in your DAGs is by using the Task Group decorator. Note that this feature requires Airflow 2.1+. The Task Group decorator works like other [decorators in Airflow](https://www.astronomer.io/guides/airflow-decorators) by allowing you to define your Task Group with less boilerplate code using the TaskFlow API. The functionality of Task Groups does not change when defining them with a decorator, but for DAG authors who use the `@task` Python task decorator in their DAGs, it may be a more stylistically consistent option.
+Another way of defining Task Groups in your DAGs is by using the Task Group decorator. Note that this feature requires Airflow 2.1+. The Task Group decorator works like other [decorators in Airflow](https://www.astronomer.io/guides/airflow-decorators) by allowing you to define your Task Group with less boilerplate code using the TaskFlow API. Using Task Group decorators doesn't change the functionality of Task Groups, but if you already use task decorators in your DAGs then they can make your code formatting more consistent.
 
-At a high level, to use the decorator you must use `@task_group` before a Python function which calls the functions of tasks that should go in the Task Group. For example:
+To use the decorator, add `@task_group` before a Python function which calls the functions of tasks that should go in the Task Group. For example:
 
 ```python
 @task_group(group_id="tasks")
@@ -69,9 +69,9 @@ def my_independent_tasks():
     task_c()
 ```
 
-This function will create a Task Group with three independent tasks that should be defined elsewhere in the DAG.
+This function creates a Task Group with three independent tasks that are defined elsewhere in the DAG.
 
-You can also create a Task Group containing dependent tasks, like this:
+You can also create a Task Group of dependent tasks:
 
 ```python
 @task_group(group_id="tasks")
@@ -132,10 +132,10 @@ The resulting DAG looks like this:
 
 ![Decorated Task Group](https://assets2.astronomer.io/main/guides/task-groups/decorated_task_group.png)
 
-There are a few things to note about this DAG and when using the Task Group decorator:
+There are a few things to consider when using the Task Group decorator:
 
-- If downstream tasks require the output of tasks that are in the Task Group, then the Task Group function must return a result. In this example, we return a dictionary with two values, one from each of the tasks in the Task Group, that are then passed to the downstream `load()` task.
-- If your Task Group function does not return any output, you will need to use bitshift operators (`<<` or `>>`) to define dependencies, rather than calling the function with the TaskFlow API.
+- If downstream tasks require the output of tasks that are in the Task Group decorator, then the Task Group function must return a result. In the previous example, we return a dictionary with two values, one from each of the tasks in the Task Group, that are then passed to the downstream `load()` task.
+- If your Task Group function returns an output, you can simply call the function from your DAG with the TaskFlow API like in the previous example. If your Task Group function does not return any output, you must use bitshift operators (`<<` or `>>`) to define dependencies to the Task Group like you would with a standard task.
 
 
 ## Dynamically Generating Task Groups

--- a/guides/task-groups.md
+++ b/guides/task-groups.md
@@ -55,6 +55,89 @@ In the Airflow UI, Task Groups look like tasks with blue shading. When we expand
 
 > **Note:** When your task is within a Task Group, your callable `task_id` will be the `task_id` prefixed with the `group_id` (i.e. `group_id.task_id`). This ensures the uniqueness of the task_id across the DAG. This is important to remember when calling specific tasks with XCOM passing or branching operator decisions.
 
+## Using the Task Group Decorator
+
+Another way of defining Task Groups in your DAGs is by using the Task Group decorator. Note that this feature requires Airflow 2.1+. The Task Group decorator works like other [decorators in Airflow](https://www.astronomer.io/guides/airflow-decorators) by allowing you to define your Task Group with less boilerplate code using the TaskFlow API. The functionality of Task Groups does not change when defining them with a decorator, but for DAG authors who use the `@task` Python task decorator in their DAGs, it may be a more stylistically consistent option.
+
+At a high level, to use the decorator you must use `@task_group` before a Python function which calls the functions of tasks that should go in the Task Group. For example:
+
+```python
+@task_group(group_id="tasks")
+def my_independent_tasks():
+    task_a()
+    task_b()
+    task_c()
+```
+
+This function will create a Task Group with three independent tasks that should be defined elsewhere in the DAG.
+
+You can also create a Task Group containing dependent tasks, like this:
+
+```python
+@task_group(group_id="tasks")
+def my_dependent_tasks():
+    return task_a(task_b(task_c()))
+```
+
+The following DAG shows a full example implementation of the Task Group decorator, including passing data between tasks before and after the Task Group:
+
+```python
+import json
+from airflow.decorators import dag, task, task_group
+
+import pendulum
+
+@dag(schedule_interval=None, start_date=pendulum.datetime(2021, 1, 1, tz="UTC"), catchup=False)
+
+def task_group_example():
+
+    @task(task_id='extract', retries=2)
+    def extract_data():
+        data_string = '{"1001": 301.27, "1002": 433.21, "1003": 502.22}'
+        order_data_dict = json.loads(data_string)
+        return order_data_dict
+
+    @task()
+    def transform_sum(order_data_dict: dict):
+        total_order_value = 0
+        for value in order_data_dict.values():
+            total_order_value += value
+
+        return {"total_order_value": total_order_value}
+
+    @task()
+    def transform_avg(order_data_dict: dict):
+        total_order_value = 0
+        for value in order_data_dict.values():
+            total_order_value += value
+            avg_order_value = total_order_value / len(order_data_dict)
+
+        return {"avg_order_value": avg_order_value}
+
+    @task_group
+    def transform_values(order_data_dict):
+        return {'avg': transform_avg(order_data_dict), 'total': transform_sum(order_data_dict)}
+
+    @task()
+    def load(order_values: dict):
+        print(f"Total order value is: {order_values['total']['total_order_value']:.2f} and average order value is: {order_values['avg']['avg_order_value']:.2f}")
+
+    load(transform_values(extract_data()))
+
+    
+task_group_example = task_group_example()
+```
+
+The resulting DAG looks like this:
+
+![Decorated Task Group](https://assets2.astronomer.io/main/guides/task-groups/decorated_task_group.png)
+
+There are a few things to note about this DAG and when using the Task Group decorator:
+
+- If downstream tasks require the output of tasks that are in the Task Group, then the Task Group function must return a result. In this example, we return a dictionary with two values, one from each of the tasks in the Task Group, that are then passed to the downstream `load()` task.
+- If your Task Group function does not return any output, you will need to use bitshift operators (`<<` or `>>`) to define dependencies, rather than calling the function with the TaskFlow API.
+
+
 ## Dynamically Generating Task Groups
 
 [Just like with DAGs](https://www.astronomer.io/guides/dynamically-generating-dags), Task Groups can be dynamically generated to make use of patterns within your code. In an ETL DAG, you might have similar downstream tasks that can be processed independently, such as when you call different API endpoints for data that needs to be processed and stored in the same way. For this use case, we can dynamically generate Task Groups by API endpoint. Just like with manually written Task Groups, generated Task Groups can be drilled into from the Airflow UI to see specific tasks. 


### PR DESCRIPTION
Title says it all. Adding a section with an example DAG we used in a recent decorators webinar on how to define task groups using decorators. @jwitz let me know if you have any comments.