### PR TITLE
Update KPO guide name

### DIFF
--- a/guides/kubepod-operator.md
+++ b/guides/kubepod-operator.md
@@ -1,6 +1,6 @@
 ---
-title: "KubernetesPodOperator on Astronomer"
-description: "Use the KubernetesPodOperator on Astronomer"
+title: "Using the KubernetesPodOperator"
+description: "Use the KubernetesPodOperator in Airflow to run tasks in Kubernetes Pods"
 date: 2018-07-17T00:00:00.000Z
 slug: "kubepod-operator"
 heroImagePath: null


### PR DESCRIPTION
This guide focuses on OSS KPO, so updating the name to be more in line with that. We'll have a tutorial down the road that focuses on using KPO on Astro.