### PR TITLE
Remove References to https://www.astronomer.io/downloads/

### DIFF
--- a/guides/get-started-airflow-2.md
+++ b/guides/get-started-airflow-2.md
@@ -68,7 +68,7 @@ This project directory is where you'll store all files necessary to build your A
 
 ## Step 3: Add Airflow 2.0 to your Dockerfile
 
-Your `Dockerfile` will include reference to a Debian-based, [Astronomer Certified](https://www.astronomer.io/downloads/) Docker Image.
+Your `Dockerfile` includes a reference to a Debian-based, Astronomer Certified Docker Image.
 
 In your Dockerfile, replace the existing FROM statement with:
 


### PR DESCRIPTION
@paolaperaza made the following request in issue [1007](https://github.com/astronomer/docs/issues/1007):

_This downloads page is an old vestige from our Astronomer Certified days and is not expected to include Astro Runtime. Before and as we complete the website work necessary to remove this page, we need to:_

_- Remove all references and links to this page from ALL docs_

_- Remove all references and links to this page from ALL Airflow Guides_

_I'm going to keep this issue here and not create one in Guides repo -- whoever takes it, could you take care of opening up a PR there too?__

This PR addresses the links in the Airflow Guides.