### PR TITLE
Managing your Connections in Airflow - Guide update

### DIFF
--- a/guides/connections.md
+++ b/guides/connections.md
@@ -7,140 +7,299 @@ heroImagePath: null
 tags: ["Connections", "Basics", "Hooks", "Operators"]
 ---
 
-This document covers how to set up various connections in Airflow. Connections defined by this process are used by [Hooks](https://airflow.apache.org/concepts.html#hooks) in order to encapsulate authentication code and common functions that are used by [Operators](https://airflow.apache.org/concepts.html#operators).
+Connections in Airflow are sets of configurations used to connect with other tools in the data ecosystem. They can be created and modified in different ways
 
-Connections can be maintained in the Airflow Interface (Menu --> Admin --> Connections).
+In this guide we will cover:
 
-> **Note:** In Airflow 2.0, Provider packages are separate from the core of Airflow, and the Connection Types available are dependent on the provider packages you have installed. For example, in order to see the Snowflake ConnType in the Airflow UI, you'll need the [Snowflake Provider](https://registry.astronomer.io/providers/snowflake) package. If you are running Airflow 2.0 on Astronomer, you can install Provider packages by adding them to your `requirements.txt` file. To learn more, read [Airflow Docs on Provider Packages](https://airflow.apache.org/docs/apache-airflow-providers/index.html) and also browse all available Providers and modules in the [Astronomer Registry](https://registry.astronomer.io/).
+- The basics on Airflow connections.
+- How to define connections using the Airflow UI.
+- How to define connections via environment variables.
+- An example showing a Snowflake connection and a Slack Webhook connection being used in a DAG.
+- Programmatically creating and modifying connections.
 
-### Example Connection Configurations
+## Assumed knowledge
 
-#### Microsoft SQL Server
+To get the most out of this guide, you should have knowledge of:
 
-* `Host`: localhost
-* `Schema`: n/a
-* `Login`: _your username_
-* `Password`: _blank_
-* `Port`: 1433
-* `Extras`: n/a
+- What Airflow is and when to use it. See [Introduction to Apache Airflow](https://www.astronomer.io/guides/intro-to-airflow/).
+- Airflow operators. See [Operators 101](https://www.astronomer.io/guides/what-is-an-operator).
 
-#### MongoDb
+## Airflow connection essentials
 
-* `Host`:
-* `Schema`: Authentication Database
-* `Login`:
-* `Password`:
-* `Port`: 27017
-* `Extras`: JSON Object of [connection options](https://docs.mongodb.com/manual/reference/connection-string/#connection-string-options)
+A connection in Airflow is a set of configurations containing the information necessary to send requests to the API of an external tool. Which information a connection needs to contain will vary based on which tool you are connecting to.
 
-#### MySQL
+Each connection is associated with a unique `conn_id`, which can be provided to operators needing a connection.
 
-* `Host`: localhost
-* `Schema`: _your database name_
-* `Login`: _your username_
-* `Password`: _blank_
-* `Port`: 3306
-* `Extras`: n/a
+Under the hood connections use Airflow [hooks](https://www.astronomer.io/guides/what-is-a-hook/) to send API requests. Many hooks to connect to external tools will have to be added to core Airflow by installing a provider package. The easiest way to find provider packages is by browsing the [Astronomer Registry](https://registry.astronomer.io/).
 
-#### S3
+For example to be able to use a connection of the 'Connection Type' `Amazon S3` Airflow will need to be able to use the `S3Hook` which is part of the [Amazon provider](https://registry.astronomer.io/providers/amazon).
 
-* `Host`: n/a
-* `Schema`: n/a
-* `Login`: n/a
-* `Password`: n/a
-* `Port`: n/a
-* `Extras`: {"aws_access_key_id":" ","aws_secret_access_key":" "}
+Astro CLI users can simply add the provider to the `packages.txt` file as shown in the example below.
 
-#### Postgres
+> **Note**: You can use hooks directly within your DAG code as shown in [Hooks 101](https://www.astronomer.io/guides/what-is-a-hook/).
 
-* `Host`: localhost
-* `Schema`: _your database name_
-* `Login`: _your username_
-* `Password`: _blank_
-* `Port`: 5432
-* `Extras`: n/a
+## Define connections in the UI
 
-#### Snowflake
+To define a connection using the Airflow UI click on the **Admin** in the navigation bar and select **Connections**.
 
-* `Host`: `https://youraccount.yourregion.snowflakecomputing.com/`
-* `Schema`: _your schema name_
-* `Login`: _your username_
-* `Password`: _your password_
-* `Port`: n/a
-* `Extras`: {"account":" ","role":" ", "warehouse":" ", "database":" ", "region":" "}
+![Connections seen from the DAG view](https://assets2.astronomer.io/main/guides/connections/DAGview_connections.png)
 
-#### Azure Data Factory
+The list of connections will be empty in a new Airflow instance. Click the blue `+` button to add a new connection.
 
-* `Host`: n/a
-* `Schema`: n/a
-* `Login`: _your ClientId_
-* `Password`: _your Client Secret_
-* `Port`: n/a
-* `Extras`: {"tenantId":" ","subscriptionId":" ", "resourceGroup":" ", "factory":" "}
+![Empty Connection](https://assets2.astronomer.io/main/guides/connections/EmptyConnection.png)
 
-#### Azure Blob Storage
+The fields on the lefthand side will change depending on which 'Connection Type' you select.
 
-* `Host`: n/a
-* `Schema`: n/a
-* `Login`: _your Storage Account name_
-* `Password`: _your Storage Account key_
-* `Port`: n/a
-* `Extras`: n/a
+> **Note**: If the connection type you are looking for is not available in the dropdown menu, make sure you correctly installed the relevant provider.  
 
-#### Azure Container Instances
+For most connections it is not necessary to specify all fields. The example below shows a connection made to an Amazon S3 bucket using the AWS access key ID as `login` an the AWS secret access key as `password` ([See AWS documentation for how to retrieve your AWS access key ID and AWS secret access key](https://docs.aws.amazon.com/powershell/latest/userguide/pstools-appendix-sign-up.html)).
 
-* `Host`: n/a
-* `Schema`: n/a
-* `Login`: _your ClientId_
-* `Password`: _your Client Secret_
-* `Port`: n/a
-* `Extras`: {"tenantId":" ","subscriptionId":" "}
+![Example AWS S3 connection](https://assets2.astronomer.io/main/guides/connections/AWSS3connection.png)
 
-Depending on the Hook or Operator used, Connections can be called directly in the code:
+Some connection types offer the possibility to test the connection from the Airflow UI. A message either confirming a successful connection or providing an error message will appear on top of the screen after running a connection test.
 
-```python
+> **Note**: Passwords are treated as a secret by Airflow and will be hidden from the user after saving the connection.
 
-postgres_query = PostgresOperator(
-    task_id="query_one",
-    postgres_conn_id=<my_postgres_conn_id>,
-    sql=<my_sql_statement>,
-    autocommit=True,
-)
+## Define connections via environment variables
+
+Connections can also be defined using environment variables. Where you can define environment variables depends on your Airflow setup. Astro CLI users can use the `.env` file for local development or specify environment variables in the Dockerfile.
+
+The connection can be provided in URI format (in this example defined from a Dockerfile).
+
+```Dockerfile
+ENV AIRFLOW_CONN_MY_CONN_ID='my-conn-type://login:password@host:port/schema?param1=val1&param2=val2'
 ```
 
+Starting in Airflow version 2.3.0+ connections can be provided as a JSON (in this example defined from `.env`).
 
-**Note**: The `Schema` field in Airflow can potentially be a source of confusion as many databases have different meanings for the term.  In Airflow a schema refers to the database name to which a connection is being made.  For example, for a Postgres connection the name of the database should be entered into the `Schema` field and the Postgres idea of schemas should be ignored (or put into the `Extras` field) when defining a connection.
+```text
+AIRFLOW_CONN_MY_CONN_ID='{
+    "conn_type": "my-conn-type",
+    "login": "my-login",
+    "password": "my-password",
+    "host": "my-host",
+    "port": 1234,
+    "schema": "my-schema",
+    "extra": {
+        "param1": "val1",
+        "param2": "val2"
+    }
+}'
+```
 
-### Programmatically Modifying Connections
+Connections that are defined using environment variables will not show up in the list of connections in the Airflow UI.
 
-The Airflow Connections class can be modified programmatically to sync with an external secrets manager:
+> **Note**: There are more ways to add connections to Airflow, for example by modifying airflow.cfg or via the CLI. It is also possible to create custom connection fields. For more in-depth information on configuring connections see ['Managing Connections'](https://airflow.apache.org/docs/apache-airflow/stable/howto/connection.html) in the Airflow documentation.
 
-```python
+> **Note**: Astro CLI users can also define connections for local development by adding them to the `airflow_settings.yaml` file.
+
+## Example: Configuring the SnowflakeToSlackOperator
+
+In this example we will configure the `SnowflakeToSlackOperator`, which necessitates a connection to Snowflake, as well as a connection to Slack. We will define the connections using the Airflow UI.
+
+Before starting Airflow, install both the [Snowflake](https://registry.astronomer.io/providers/snowflake) and the [Slack provider](https://registry.astronomer.io/providers/slack). Astro CLI users can add them to `requirements.txt`:
+
+```text
+apache-airflow-providers-snowflake
+apache-airflow-providers-slack
+```
+
+In the Airflow UI navigate to the list of connections and a connection of the 'Connection Type' `Snowflake`. You will need to provide the following parameters:
+
+- Connection Id: `snowflake_conn` (or another string that has not been used for a different connection already)
+- Connection Type: `Snowflake`
+- Schema: The schema of your database that you want to query.
+- Login: Your Snowflake login name.
+- Password: Your Snowflake login password.
+- Account: Your Snowflake account in the format xy12345.region
+- Database: The database you want to query
+
+You can leave the other fields empty. Test the connection by clicking on the `Test` button.
+
+The screenshot below shows the confirmation that the connection to Snowflake was successful. The example queries a schema in the Snowflake example database.
+
+![Successful Connection to Snowflake](https://assets2.astronomer.io/main/guides/connections/SuccessfulSnowflakeConn.png)
+
+Next the connection to Slack is set up. To post a message to a slack channel you will need to create a Slack app for your server and configure Incoming Webhooks. A step-by-step explanation of this process can be found in the [Slack Documentation](https://api.slack.com/messaging/webhooks).
+
+To connect to Slack from the Airflow UI you only have to provide a few parameters:
+
+- Connection Id: `slack_conn` (or another string that has not been used for a different connection already)
+- Connection Type: `Slack Webhook`
+- Host: `https://hooks.slack.com.services` (the first part of the Webhook URL)
+- Password: The second part of the Webhook URL. It will have the format `T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX`
+
+Test the connection by clicking on the `Test` button.
+
+The last step is writing the DAG using the `SnowflakeToSlackOperator`. This operator queries the provided Snowflake database using a SQL statement and can directly post parts of the query to Slack.
+
+In the example the `ORDERS` table from the `TPCH_SF1` schema in the `SNOWFLAKE_SAMPLE_DATA` database is queried for its total count of rows and the sum of the `O_TOTALPRICE` column. The name of the table and of the column are provided using the operator's params argument and [Jinja templating](https://www.astronomer.io/guides/templating/).
+
+The result of the query provided to the `sql` parameter is accessible as a Pandas dataframe called `results_df`. In the `slack_message` we index into the `results_df` by providing the column name. Note that the operator will save the column names in upper case even if they were provided as lower case in the SQL statement.
+
+
+```Python
+from airflow import DAG
+from datetime import datetime
+from airflow.providers.snowflake.transfers.snowflake_to_slack import (
+    SnowflakeToSlackOperator
+)
+
+with DAG(
+    dag_id="snowflake_to_slack_dag",
+    start_date=datetime(2022, 7, 1),
+    schedule_interval=None,
+    catchup=False
+) as dag:
+
+    transfer_task = SnowflakeToSlackOperator(
+        task_id="transfer_task",
+        snowflake_conn_id="snowflake_conn",
+        slack_conn_id="slack_conn",
+
+        # params can be access within the operator using Jinja templating
+        params={
+            "table_name": "ORDERS",
+            "col_to_sum": "O_TOTALPRICE"
+        },
+
+        # the SQL statement retrieves row_count of the table
+        # and the total sum of one column
+        sql="""
+            SELECT
+              COUNT(*) AS row_count,
+              SUM({{ params.col_to_sum }}) AS sum_price
+            FROM {{ params.table_name }}
+        """,
+
+        # the message to be printed to Slack can use Jinja templating as well
+        slack_message="""The table {{ params.table_name }} has
+            => {{ results_df.ROW_COUNT[0] }} entries
+            => with a total price of {{results_df.SUM_PRICE[0]}}"""
+    )
+```
+
+Running the DAG results in the message being printed to Slack.
+
+![Slack Message](https://assets2.astronomer.io/main/guides/connections/SlackMessage.png)
+
+## Programmatically creating and modifying connections
+
+Connections can be created and modified programmatically to sync with an external secrets manager.
+
+To access connection information from within your DAG you will need to provide the session information to a Python function by using the `provide_session` function from the `airflow.utils.db` module as a decorator.
+
+The DAG below shows the steps necessary to print out the host parameter of an existing connection.
+
+- Import the `provide_session` function and the `Connection` object.
+- Provide the name of the connection to examine. In this example the name is `my_database_connection`.
+- Create a function using the `provide_session` function as a decorator.
+- In that function query the `session` object for any `Connection` objects and filters for connections with the `conn_id` `my_database_connection` and use the `one_or_none()` method on the query to extract the search results. The last line of the function prints the `host` information from this result.
+- Provide the function to a PythonOperator in order to run it within a DAG.
+
+```Python
+from airflow import DAG
+from datetime import datetime
+from airflow.operators.python import PythonOperator
+from airflow.utils.db import provide_session
+from airflow.models import Connection
+
+CONN_ID = "my_database_connection"
+
+@provide_session
+def print_conn_host(conn_id=None, session=None):
+    conn_query = session.query(Connection).filter(
+        Connection.conn_id == conn_id,)
+
+    conn_query_result = conn_query.one_or_none()
+
+    print(conn_query_result.host)
+
+with DAG(
+    dag_id="print_host_from_connection_id_dag",
+    start_date=datetime(2022, 8, 1),
+    schedule_interval=None,
+    catchup=False
+) as dag:
+
+    print_result = PythonOperator(
+        task_id="print_result",
+        python_callable=print_conn_host,
+        op_kwargs={"conn_id": CONN_ID}
+    )
+```
+
+Knowing that connection information is programmatically accessible it is possible to build functions which are able to modify connection information. A possible use case is to synchronize information with an external secrets manager.
+
+The function below show a possible implementation of such a synchronization.
+
+- `sources` are connections with their information stored in a secrets manager.
+- Looping through each `source` the `port` property will be checked to be numeric.
+- The current session is queried to check if a connection with the same `conn_id` as the connection from the `source` already exists.
+- If no connection of the same id exists a new connection is created.
+- If a connection of the same id exists it will be overwritten with the new information from the `source`.
+
+```Python
+from airflow.utils.db import provide_session
+from airflow.models import Connection
+import logging
+
+# get the airflow.task logger
+task_logger = logging.getLogger('airflow.task')
+
 @provide_session
 def create_connections(session=None):
-    sources = {"This could come from secrets manager"}
-​
+
+    # query the API of your secrets manager here
+    sources = {"Connection information from the secrets manager"}
+
+    # iterating over sources from the secrets manager
     for source in sources:
+
+        # check that the port property of the sources are numeric
         try:
             int(source['port'])
         except:
-            logger.info("Port is not numeric for source")
+            task_logger.info("Port is not numeric for source")
             continue
 
+        # get properties of the source connection, you may need to adjust this
+        # for different connection types
         host = source.get("host", "")
         port = source.get("port", "5439")
         db = source.get("db", "")
         user = source.get("user", "")
         password = source.get("pw", "")
 ​
+        # the code below attempts to either modify an existing connection or
+        # create a new one
         try:
-            connection_query = session.query(Connection).filter(Connection.conn_id == source['name'],)
+            # query connection information from the current session
+            # to see if a connection with the conn_id source['name'] already
+            # exists
+            connection_query = session.query(Connection).filter(
+                Connection.conn_id == source['name'],)
             connection_query_result = connection_query.one_or_none()
+
+            # if the result of the query is None, this conn_id has not been
+            # used before and the new connection can be created from the
+            # information pulled from the source in the secrets manager
             if not connection_query_result:                    
-                connection = Connection(conn_id=source['name'], conn_type='postgres', host=host, port=port,
-                                        login=user, password=password, schema=db)
+                connection = Connection(
+                                 conn_id=source['name'],
+                                 conn_type='postgres',
+                                 host=host,
+                                 port=port,
+                                 login=user,
+                                 password=password,
+                                 schema=db
+                             )
+                # add and commit the new connection to the session
                 session.add(connection)
                 session.commit()
+
+            # if the conn_id already exists the connection is modified
+            # with the information from the source in the secrets manager
             else:
                 connection_query_result.host = host
                 connection_query_result.login = user
@@ -149,11 +308,10 @@ def create_connections(session=None):
                 connection_query_result.set_password(password)
                 session.add(connection_query_result)
                 session.commit()
+
+        # in case creating the connection fails, log the error message
         except Exception as e:
-            logger.info(
+            task_logger.info(
                 "Failed creating connection"
-            logger.info(e)
-
+            task_logger.info(e)
 ```
-
-**Note:** The `conn_id` does not have a uniqueness constraint within Airflow, so be sure to delete exist connections before programmatically creating new ones. If two `Connections` have the same name, Airflow will randomly pick which one to use.

--- a/guides/connections.md
+++ b/guides/connections.md
@@ -43,7 +43,7 @@ Each connection has a unique `conn_id` which can be provided to operators and [h
 
 To standardize connections, Airflow includes many different **connection types** for connecting to specific types of systems. There are general connection types for connecting to large clouds, such as `aws_default` and `gcp_default`, as well as connection types for specific services like `azure_service_bus_default`.
 
-Each connection type requires different configurations and values based on the service it's connecting to. There are a couple of ways find the information you need to provide for a particular connection type:
+Each connection type requires different configurations and values based on the service it's connecting to. There are a couple of ways to find the information you need to provide for a particular connection type:
 
 - Open the relevant provider's page in the [Astronomer Registry](https://registry.astronomer.io/providers/) and go to the **Docs** tab to access the Apache Airflow documentation for the provider. Most commonly used providers will have documentation on each of their associated connection types. For example, you can find information on how to set up different connections to Azure on the [Azure provider docs](https://registry.astronomer.io/providers/microsoft-azure).
 - Check the documentation of the external tool you are connecting to and see if it offers guidance on how to authenticate.
@@ -87,7 +87,7 @@ The environment variable used for the connection must be formatted as `AIRFLOW_C
 ENV AIRFLOW_CONN_MYCONNID='my-conn-type://login:password@host:port/schema?param1=val1&param2=val2'
 
 # an example of a connection to snowflake defined as a URI
-ENV AIRFLOW_CONN_snowflake_conn='snowflake://LOGIN:PASSWORD@/?account=xy12345&region=eu-central-1'
+ENV AIRFLOW_CONN_SNOWFLAKE_CONN='snowflake://LOGIN:PASSWORD@/?account=xy12345&region=eu-central-1'
 
 ```
 

--- a/guides/connections.md
+++ b/guides/connections.md
@@ -7,15 +7,15 @@ heroImagePath: null
 tags: ["Connections", "Basics", "Hooks", "Operators"]
 ---
 
-Connections in Airflow are sets of configurations used to connect with other tools in the data ecosystem. They can be created and modified in different ways
+Connections in Airflow are sets of configurations used to connect with other tools in the data ecosystem. They are required by most hooks and operators, and can be created and modified in different ways.
 
 In this guide we will cover:
 
-- The basics on Airflow connections.
+- The basics of Airflow connections.
 - How to define connections using the Airflow UI.
-- How to define connections via environment variables.
+- How to define connections using environment variables.
 - An example showing a Snowflake connection and a Slack Webhook connection being used in a DAG.
-- Programmatically creating and modifying connections.
+- How to programmatically create and modify connections.
 
 ## Assumed knowledge
 
@@ -26,21 +26,19 @@ To get the most out of this guide, you should have knowledge of:
 
 ## Airflow connection essentials
 
-A connection in Airflow is a set of configurations containing the information necessary to send requests to the API of an external tool. Which information a connection needs to contain will vary based on which tool you are connecting to.
+A connection in Airflow is a set of configurations containing the information necessary to send requests to the API of an external tool. The information a connection needs to contain will vary based on which tool you are connecting to.
 
-Each connection is associated with a unique `conn_id`, which can be provided to operators needing a connection.
+Each connection is associated with a unique `conn_id`, which can be provided to operators requiring a connection.
 
-Under the hood connections use Airflow [hooks](https://www.astronomer.io/guides/what-is-a-hook/) to send API requests. Many hooks to connect to external tools will have to be added to core Airflow by installing a provider package. The easiest way to find provider packages is by browsing the [Astronomer Registry](https://registry.astronomer.io/).
+Under the hood, Airflow [hooks](https://www.astronomer.io/guides/what-is-a-hook/) use connections to authenticate to external systems in order to send API requests. Most hooks that require connections are part of provider packages, which can be discovered on the [Astronomer Registry](https://registry.astronomer.io/).
 
-For example to be able to use a connection of the 'Connection Type' `Amazon S3` Airflow will need to be able to use the `S3Hook` which is part of the [Amazon provider](https://registry.astronomer.io/providers/amazon).
+For example, the `S3Hook`, which is part of the [Amazon provider (https://registry.astronomer.io/providers/amazon), requires a connection of the type `Amazon S3`.
 
-Astro CLI users can simply add the provider to the `packages.txt` file as shown in the example below.
 
-> **Note**: You can use hooks directly within your DAG code as shown in [Hooks 101](https://www.astronomer.io/guides/what-is-a-hook/).
 
 ## Define connections in the UI
 
-To define a connection using the Airflow UI click on the **Admin** in the navigation bar and select **Connections**.
+The most common way of defining a connection is using the Airflow UI. Click on the **Admin** in the navigation bar and select **Connections**.
 
 ![Connections seen from the DAG view](https://assets2.astronomer.io/main/guides/connections/DAGview_connections.png)
 
@@ -48,11 +46,11 @@ The list of connections will be empty in a new Airflow instance. Click the blue 
 
 ![Empty Connection](https://assets2.astronomer.io/main/guides/connections/EmptyConnection.png)
 
-The fields on the lefthand side will change depending on which 'Connection Type' you select.
+The fields on the lefthand side may change depending on which 'Connection Type' you select.
 
-> **Note**: If the connection type you are looking for is not available in the dropdown menu, make sure you correctly installed the relevant provider.  
+> **Note**: Specific connection types will only be available in the dropdown menu if the relevant provider is installed in your Airflow environment.  
 
-For most connections it is not necessary to specify all fields. The example below shows a connection made to an Amazon S3 bucket using the AWS access key ID as `login` an the AWS secret access key as `password` ([See AWS documentation for how to retrieve your AWS access key ID and AWS secret access key](https://docs.aws.amazon.com/powershell/latest/userguide/pstools-appendix-sign-up.html)).
+For most connections it is not necessary to specify all fields. The example below shows a connection made to an Amazon S3 bucket using the AWS access key ID as `login` and the AWS secret access key as `password` ([See AWS documentation for how to retrieve your AWS access key ID and AWS secret access key](https://docs.aws.amazon.com/powershell/latest/userguide/pstools-appendix-sign-up.html)).
 
 ![Example AWS S3 connection](https://assets2.astronomer.io/main/guides/connections/AWSS3connection.png)
 
@@ -62,7 +60,7 @@ Some connection types offer the possibility to test the connection from the Airf
 
 ## Define connections via environment variables
 
-Connections can also be defined using environment variables. Where you can define environment variables depends on your Airflow setup. Astro CLI users can use the `.env` file for local development or specify environment variables in the Dockerfile.
+Connections can also be defined using environment variables. Astro CLI users can use the `.env` file for local development, or specify environment variables in the Dockerfile.
 
 The connection can be provided in URI format (in this example defined from a Dockerfile).
 
@@ -70,7 +68,7 @@ The connection can be provided in URI format (in this example defined from a Doc
 ENV AIRFLOW_CONN_MY_CONN_ID='my-conn-type://login:password@host:port/schema?param1=val1&param2=val2'
 ```
 
-Starting in Airflow version 2.3.0+ connections can be provided as a JSON (in this example defined from `.env`).
+In Airflow 2.3+, connections can alternatively be provided as a JSON (in this example defined from `.env`).
 
 ```text
 AIRFLOW_CONN_MY_CONN_ID='{
@@ -87,7 +85,7 @@ AIRFLOW_CONN_MY_CONN_ID='{
 }'
 ```
 
-Connections that are defined using environment variables will not show up in the list of connections in the Airflow UI.
+Note that connections that are defined using environment variables will not show up in the list of connections in the Airflow UI.
 
 > **Note**: There are more ways to add connections to Airflow, for example by modifying airflow.cfg or via the CLI. It is also possible to create custom connection fields. For more in-depth information on configuring connections see ['Managing Connections'](https://airflow.apache.org/docs/apache-airflow/stable/howto/connection.html) in the Airflow documentation.
 
@@ -95,16 +93,16 @@ Connections that are defined using environment variables will not show up in the
 
 ## Example: Configuring the SnowflakeToSlackOperator
 
-In this example we will configure the `SnowflakeToSlackOperator`, which necessitates a connection to Snowflake, as well as a connection to Slack. We will define the connections using the Airflow UI.
+In this example, we will configure the `SnowflakeToSlackOperator`, which requires connections to Snowflake and Slack. We will define the connections using the Airflow UI.
 
-Before starting Airflow, install both the [Snowflake](https://registry.astronomer.io/providers/snowflake) and the [Slack provider](https://registry.astronomer.io/providers/slack). Astro CLI users can add them to `requirements.txt`:
+Before starting Airflow, we need to install both the [Snowflake](https://registry.astronomer.io/providers/snowflake) and the [Slack provider](https://registry.astronomer.io/providers/slack). Astro CLI users can add them to `requirements.txt`:
 
 ```text
 apache-airflow-providers-snowflake
 apache-airflow-providers-slack
 ```
 
-In the Airflow UI navigate to the list of connections and a connection of the 'Connection Type' `Snowflake`. You will need to provide the following parameters:
+In the Airflow UI, we can navigate to the list of connections and add a connection of the 'Connection Type' `Snowflake`. The following parameters are required:
 
 - Connection Id: `snowflake_conn` (or another string that has not been used for a different connection already)
 - Connection Type: `Snowflake`
@@ -116,13 +114,13 @@ In the Airflow UI navigate to the list of connections and a connection of the 'C
 
 You can leave the other fields empty. Test the connection by clicking on the `Test` button.
 
-The screenshot below shows the confirmation that the connection to Snowflake was successful. The example queries a schema in the Snowflake example database.
+The screenshot below shows the confirmation that the connection to Snowflake was successful.
 
 ![Successful Connection to Snowflake](https://assets2.astronomer.io/main/guides/connections/SuccessfulSnowflakeConn.png)
 
-Next the connection to Slack is set up. To post a message to a slack channel you will need to create a Slack app for your server and configure Incoming Webhooks. A step-by-step explanation of this process can be found in the [Slack Documentation](https://api.slack.com/messaging/webhooks).
+Next we set up a connection to Slack. To post a message to a Slack channel, you will need to create a Slack app for your server and configure incoming webhooks. A step-by-step explanation of this process can be found in the [Slack Documentation](https://api.slack.com/messaging/webhooks).
 
-To connect to Slack from the Airflow UI you only have to provide a few parameters:
+To connect to Slack from Airflow, you only have to provide a few parameters:
 
 - Connection Id: `slack_conn` (or another string that has not been used for a different connection already)
 - Connection Type: `Slack Webhook`

--- a/guides/connections.md
+++ b/guides/connections.md
@@ -53,7 +53,7 @@ Each connection type requires different configurations and values based on the s
 
 The most common way of defining a connection is using the Airflow UI. Go to **Admin** > **Connections** to access the **Connections** page.
 
-![Connections seen from the DAG view](https://assets2.astronomer.io/main/guides/connections/DAGview_connections.png)
+![Connections seen from the DAG view](https://assets2.astronomer.io/main/guides/connections/DAGview_connections_cropped.png)
 
 Airflow doesn't include any configured connections by default. To create a new connection, click the blue **+** button.
 

--- a/guides/connections.md
+++ b/guides/connections.md
@@ -49,7 +49,7 @@ Each connection type requires different configurations and values based on the s
 - Check the documentation of the external tool you are connecting to and see if it offers guidance on how to authenticate.
 - Refer to the source code of the hook that is being used by your operator.
 
-## Define connections in the UI
+## Defining connections in the UI
 
 The most common way of defining a connection is using the Airflow UI. Go to **Admin** > **Connections** to access the **Connections** page.
 
@@ -63,11 +63,11 @@ As you update the **Connection Type** field, notice how the other available fiel
 
 > **Note**: Specific connection types will only be available in the dropdown menu if the relevant provider is installed in your Airflow environment.  
 
-You don't have to specify every field on most connections. However, the values marked as required in the Airflow UI can be misleading. For example to set up a connection to a PostgreSQL database, we need to reference the [PostgreSQL provider documentation](https://airflow.apache.org/docs/apache-airflow-providers-postgres/stable/connections/postgres.html) to learn that the connection requires a `Host`, a user name as `login` and a password in the `password` field.
+You don't have to specify every field on most connections. However, the values marked as required in the Airflow UI can be misleading. For example to set up a connection to a PostgreSQL database, we need to reference the [PostgreSQL provider documentation](https://airflow.apache.org/docs/apache-airflow-providers-postgres/stable/connections/postgres.html) to learn that the connection requires a `Host`, a user name as `login`, and a password in the `password` field.
 
 ![Example PostgreSQL connection](https://assets2.astronomer.io/main/guides/connections/PostgreSQLconnection.png)
 
-Any parameters that do not have specific fields in the connection form can be provided to the **Extra** field as a JSON dictionary. For example, you can add the `sslmode` or a client `sslkey` in the **Extra** field of your PostgreSQL connection.
+Any parameters that don't have specific fields in the connection form can be defined in the **Extra** field as a JSON dictionary. For example, you can add the `sslmode` or a client `sslkey` in the **Extra** field of your PostgreSQL connection.
 
 Starting in Airflow 2.2, you can test some connection types from the Airflow UI with the **Test** button. After running a connection test, a message appears on the top of the screen showing either a success confirmation or an error message.
 
@@ -93,7 +93,7 @@ ENV AIRFLOW_CONN_snowflake_conn='snowflake://LOGIN:PASSWORD@/?account=xy12345&re
 
 In Airflow 2.3+, connections can be provided to an environment variable as a JSON dictionary:
 
-```text
+```json
 # example of a connection defined as a JSON file in your `.env` file
 AIRFLOW_CONN_MYCONNID='{
     "conn_type": "my-conn-type",

--- a/guides/connections.md
+++ b/guides/connections.md
@@ -14,7 +14,6 @@ In this guide we will cover:
 - The basics of Airflow connections.
 - How to define connections using the Airflow UI.
 - How to define connections using environment variables.
-- How to programmatically create and modify connections.
 - An example showing a Snowflake connection and a Slack Webhook connection being used in a DAG.
 
 ## Assumed knowledge

--- a/guides/connections.md
+++ b/guides/connections.md
@@ -7,7 +7,7 @@ heroImagePath: null
 tags: ["Connections", "Basics", "Hooks", "Operators"]
 ---
 
-Connections in Airflow are sets of configurations used to connect with other tools in the data ecosystem. They are required by most hooks and operators, and can be created and modified in different ways.
+Connections in Airflow are sets of configurations used to connect with other tools in the data ecosystem. Because most hooks and operators rely on connections to send and retrieve data from external systems, understanding how to create and configure them is essential for running Airflow in a production environment.
 
 In this guide we will cover:
 
@@ -26,7 +26,7 @@ To get the most out of this guide, you should have knowledge of:
 
 ## Airflow connection basics
 
-A connection in Airflow is a set of configurations containing the information necessary to send requests to the API of an external tool. The information contained in a connection will vary based on the requirements of the external tool. In most cases, a connection will require login credentials or a private key in order to authenticate Airflow to the external tool.
+A Airflow connection is a set of configurations for sending requests to the API of an external tool. In most cases, a connection requires login credentials or a private key to authenticate Airflow to the external tool.
 
 Airflow connections can be created by using one of the following methods:
 
@@ -37,55 +37,56 @@ Airflow connections can be created by using one of the following methods:
 - The [`airflow.cfg` file](https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html)
 - The [Airflow CLI](https://airflow.apache.org/docs/apache-airflow/stable/usage-cli.html)
 
-In this guide we will show how to add connections using the Airflow UI and environment variables methods. For more in-depth information on configuring connections using the other methods, see the REST API documentation, as well as ['Managing Connections'](https://airflow.apache.org/docs/apache-airflow/stable/howto/connection.html) and ['Secrets Backend'](https://airflow.apache.org/docs/apache-airflow/stable/security/secrets/secrets-backend/index.html) in the Airflow documentation.
+This guide focuses on how to add connections using both the Airflow UI and environment variables. For more in-depth information on configuring connections using the other methods, see the [REST API reference](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html#tag/Connection), [Managing Connections](https://airflow.apache.org/docs/apache-airflow/stable/howto/connection.html) and [Secrets Backend](https://airflow.apache.org/docs/apache-airflow/stable/security/secrets/secrets-backend/index.html) in the Airflow documentation.
 
-Each connection is associated with a unique `conn_id`, which can be provided to operators and hooks requiring a connection.
+Each connection has a unique `conn_id` which can be provided to operators and hooks that require a connection.
 
 Under the hood, Airflow [hooks](https://www.astronomer.io/guides/what-is-a-hook/) use connections to authenticate to external systems in order to send API requests. Most hooks that require connections are part of provider packages.
 
-There are a couple of ways you can find what information needs to be provided for a particular connection type:
+To standardize connections, Airflow includes many different **connection types** for connecting to specific types of systems. There are general connection types for connecting to large clouds, such as `aws_default` and `gcp_default`, as well as connection types for specific services like `azure_service_bus_default`. 
 
-- Search for the relevant provider in the [Astronomer Registry](https://registry.astronomer.io/), and click on the `Docs` button to find documentation for the provider. Most commonly used providers will have documentation on each of their associated `Connection types`. For example, you can find information on how to set up different connections to Azure on the [Connection Types page of the Azure provider](https://airflow.apache.org/docs/apache-airflow-providers-microsoft-azure/stable/connections/index.html).
+Each connection type requires different configurations and values based on the service it's connecting to. There are a couple of ways find the information you need to provide for a particular connection type:
+
+- Open the relevant provider's page in the [Astronomer Registry](https://registry.astronomer.io/providers/) and go to the **Docs** tab to access the Apache Airflow documentation for the provider. Most commonly used providers will have documentation on each of their associated connection types. For example, you can find information on how to set up different connections to Azure on the [Azure provider docs](https://registry.astronomer.io/providers/microsoft-azure).
 - Check the documentation of the external tool you are connecting to and see if it offers guidance on how to authenticate.
 - Refer to the source code of the hook that is being used by your operator.
 
-For example, the `S3Hook`, which is part of the [Amazon provider](https://registry.astronomer.io/providers/amazon), requires a connection of the type `Amazon S3`.
 
 ## Define connections in the UI
 
-The most common way of defining a connection is using the Airflow UI. Click on the **Admin** tab in the navigation bar and select **Connections**.
+The most common way of defining a connection is using the Airflow UI. Go to **Admin** > **Connections** to access the **Connections** page.
 
 ![Connections seen from the DAG view](https://assets2.astronomer.io/main/guides/connections/DAGview_connections.png)
 
-The list of connections will be empty in a new Airflow instance. Click the blue `+` button to add a new connection.
+Airflow doesn't include any configured connections by default. To create a new connection, click the blue **+** button.
 
 ![Empty Connection](https://assets2.astronomer.io/main/guides/connections/EmptyConnection.png)
 
-The fields on the lefthand side may change depending on which 'Connection Type' you select.
+As you update the **Connection Type** field, notice how the other available fields change. Each connection type requires different kinds of information. 
 
 > **Note**: Specific connection types will only be available in the dropdown menu if the relevant provider is installed in your Airflow environment.  
 
-For most connections it is not necessary to specify all fields. The example below shows a connection made to an Amazon S3 bucket. Referencing the [Airflow AWS provider documentation](https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/connections/aws.html) you can learn that the mandatory information needed to create this connection are the AWS access key ID as `login` and the AWS secret access key as `password` (See the [AWS documentation](https://docs.aws.amazon.com/powershell/latest/userguide/pstools-appendix-sign-up.html) for how to retrieve your AWS access key ID and AWS secret access key).
+You don't have to specify every field on most connections. However, the values marked as required in the Airflow UI can be misleading. For example, the following example is a connection for an Amazon S3 bucket. We need to reference the [Airflow AWS provider documentation](https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/connections/aws.html) to learn that the connection requires the AWS access key ID as `login` and the AWS secret access key as `password`.
 
 ![Example AWS S3 connection](https://assets2.astronomer.io/main/guides/connections/AWSS3connection.png)
 
-Any required parameters that do not have specific fields in the connection form can be provided to the `Extra` field as a JSON dictionary. For example, you can add the [ARN of a role](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html) to assume when logging into AWS by entering `{"role_arn":"arn:aws:iam::123456789012:role/my_role_name"}` in the `Extra` field. To learn more about additional parameters for a specific connection type, refer to the documentation of the relevant provider package.
+Any required parameters that do not have specific fields in the connection form can be provided to the **Extra** field as a JSON dictionary. For example, you can add the [ARN of a role](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html) to assume when logging into AWS by specifying `{"role_arn":"arn:aws:iam::123456789012:role/my_role_name"}` in the **Extra** field.
 
-In Airflow version 2.2+, you can test some connection types from the Airflow UI with the `Test` button. After running a connection test, a message will appear on the top of the screen either confirming a successful connection or providing an error message.
+Starting in Airflow 2.2, you can test some connection types from the Airflow UI with the **Test** button. After running a connection test, a message appears on the top of the screen showing either a success confirmation or an error message.
 
 ## Define connections via environment variables
 
-Connections can also be defined using environment variables. Astro CLI users can use the `.env` file for local development, or specify environment variables in the Dockerfile.
+Connections can also be defined using environment variables. If you use the Astro CLI, you use the `.env` file for local development or specify environment variables in your project's Dockerfile.
 
 > **Note**: If you are synchronizing your project to a remote repository, don't save sensitive information in your Dockerfile. In this case, using either a secrets backend, Airflow connections defined in the UI, or `.env` locally are preferred so as to not expose secrets in plain text.
 
-The environment variable used for the connection needs to be in the form of `AIRFLOW_CONN_YOURCONNID` and can be provided either in URI or, starting with Airflow 2.3, in JSON format.
+The environment variable used for the connection must be formatted as `AIRFLOW_CONN_YOURCONNID` and can be provided either as a Uniform Resource Identifier (URI) or, starting in Airflow 2.3, in JSON.
 
-[URI (Uniform Resource Identifier)](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier) is a format designed to contain all necessary connection information in one string, starting with the connection type, followed by login, password and host. In many cases a specific port, schema, and additional parameters will be added.
+[URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier) is a format designed to contain all necessary connection information in one string, starting with the connection type, followed by login, password and host. In many cases a specific port, schema, and additional parameters must be added.
 
 ```Dockerfile
 
-# the general format of a URI connection
+# the general format of a URI connection that is defined in your Dockerfile
 ENV AIRFLOW_CONN_MYCONNID='my-conn-type://login:password@host:port/schema?param1=val1&param2=val2'
 
 # an example of a connection to snowflake defined as a URI
@@ -93,9 +94,10 @@ ENV AIRFLOW_CONN_snowflake_conn='snowflake://LOGIN:PASSWORD@/?account=xy12345&re
 
 ```
 
-In Airflow 2.3+, connections can alternatively be provided as a JSON dictionary (in this example defined in `.env`).
+In Airflow 2.3+, connections can be provided to an environment variable as a JSON dictionary:
 
 ```text
+# example of a connection defined as a JSON file in your `.env` file
 AIRFLOW_CONN_MYCONNID='{
     "conn_type": "my-conn-type",
     "login": "my-login",
@@ -110,28 +112,28 @@ AIRFLOW_CONN_MYCONNID='{
 }'
 ```
 
-Note that connections that are defined using environment variables will not show up in the list of connections in the Airflow UI.
+Note that connections that are defined using environment variables do not appear in the Airflow UI's list of available connections.
 
 ## Masking sensitive information
 
-Connections often contain sensitive credentials. By default, Airflow will hide the connection password, both in the UI and in the Airflow logs. Values from the connection's `Extra` field will also be hidden if their key contains any of the words listed in the environment variable `AIRFLOW__CORE__SENSITIVE_VAR_CONN_NAMES`, as long as `AIRFLOW__CORE__HIDE_SENSITIVE_VAR_CONN_FIELDS` is set to `True`. You can find more information on masking, including a list of the default values in this environment variable, in the Airflow documentation on [Masking sensitive data](https://airflow.apache.org/docs/apache-airflow/stable/security/secrets/mask-sensitive-values.html).
+Connections often contain sensitive credentials. By default, Airflow hides the `password` field, both in the UI and in the Airflow logs. If `AIRFLOW__CORE__HIDE_SENSITIVE_VAR_CONN_FIELDS` is set to `True`, values from the connection's `Extra` field are also hidden if their keys contain any of the words listed in  `AIRFLOW__CORE__SENSITIVE_VAR_CONN_NAMES`. You can find more information on masking, including a list of the default values in this environment variable, in the Airflow documentation on [Masking sensitive data](https://airflow.apache.org/docs/apache-airflow/stable/security/secrets/mask-sensitive-values.html).
 
 ## Example: Configuring the SnowflakeToSlackOperator
 
 In this example, we configure the `SnowflakeToSlackOperator`, which requires connections to Snowflake and Slack. We define the connections using the Airflow UI.
 
-Before starting Airflow, we need to install both the [Snowflake](https://registry.astronomer.io/providers/snowflake) and the [Slack provider](https://registry.astronomer.io/providers/slack). Astro CLI users can add them to `requirements.txt`:
+Before starting Airflow, we need to install both the [Snowflake](https://registry.astronomer.io/providers/snowflake) and the [Slack provider](https://registry.astronomer.io/providers/slack). If you use the Astro CLI, you can can add install the packages by adding the following lines to your Astro project's `requirements.txt` file:
 
 ```text
 apache-airflow-providers-snowflake
 apache-airflow-providers-slack
 ```
 
-In the Airflow UI, we navigate to the list of connections and add a connection of the 'Connection Type' `Snowflake`. The following parameters are required:
+Open the Airflow UI and create a new connection. Set the **Connection Type** to `Snowflake`. This connection type requires the following parameters:
 
-- Connection Id: `snowflake_conn` (or another string that has not been used for a different connection already)
+- Connection Id: `snowflake_conn` or any other string that is not already in use by an existing connection
 - Connection Type: `Snowflake`
-- Account: Your Snowflake account in the format xy12345.region
+- Account: Your Snowflake account in the format `xy12345.region`
 - Login: Your Snowflake login name.
 - Password: Your Snowflake login password.
 
@@ -141,14 +143,14 @@ The screenshot below shows the confirmation that the connection to Snowflake was
 
 ![Successful Connection to Snowflake](https://assets2.astronomer.io/main/guides/connections/SuccessfulSnowflakeConn.png)
 
-Next we set up a connection to Slack. To post a message to a Slack channel, you will need to create a Slack app for your server and configure incoming webhooks. A step-by-step explanation of this process can be found in the [Slack Documentation](https://api.slack.com/messaging/webhooks).
+Next we set up a connection to Slack. To post a message to a Slack channel, you need to create a Slack app for your server and configure incoming webhooks. See the [Slack Documentation](https://api.slack.com/messaging/webhooks) for setup steps.
 
 To connect to Slack from Airflow, you only have to provide a few parameters:
 
 - Connection Id: `slack_conn` (or another string that has not been used for a different connection already)
 - Connection Type: `Slack Webhook`
-- Host: `https://hooks.slack.com.services` (the first part of the Webhook URL)
-- Password: The second part of the Webhook URL. It will have the format `T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX`
+- Host: `https://hooks.slack.com.services`, or the the first part of your Webhook URL
+- Password: The second part of your Webhook URL in the format `T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX`
 
 Test the connection by clicking on the `Test` button.
 

--- a/guides/connections.md
+++ b/guides/connections.md
@@ -30,12 +30,12 @@ A connection in Airflow is a set of configurations containing the information ne
 
 Airflow connections can be created by using one of the following methods:
 
-- The Airflow UI
-- Environment variables
+- The [Airflow UI](https://www.astronomer.io/guides/airflow-ui/)
+- [Environment variables](https://airflow.apache.org/docs/apache-airflow/stable/cli-and-env-variables-ref.html#environment-variables)
 - The [Airflow REST API](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html#tag/Connection)
-- A secrets backend (a system for managing secrets external to Airflow)
-- The `airflow.cfg` file
-- The Airflow CLI
+- A [secrets backend](https://airflow.apache.org/docs/apache-airflow/stable/security/secrets/secrets-backend/index.html) (a system for managing secrets external to Airflow)
+- The [`airflow.cfg` file](https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html)
+- The [Airflow CLI](https://airflow.apache.org/docs/apache-airflow/stable/usage-cli.html)
 
 In this guide we will show how to add connections using the Airflow UI and environment variables methods. For more in-depth information on configuring connections using the other methods, see the REST API documentation, as well as ['Managing Connections'](https://airflow.apache.org/docs/apache-airflow/stable/howto/connection.html) and ['Secrets Backend'](https://airflow.apache.org/docs/apache-airflow/stable/security/secrets/secrets-backend/index.html) in the Airflow documentation.
 
@@ -45,14 +45,11 @@ Under the hood, Airflow [hooks](https://www.astronomer.io/guides/what-is-a-hook/
 
 There are a couple of ways you can find what information needs to be provided for a particular connection type:
 
-- Search for the relevant provider in the [Astronomer Registry](https://registry.astronomer.io/), and click on the `Docs` button to find documentation for provider. Most commonly used providers will have documentation on each of their associated `Connection types`. For example, you can find information on how to set up different connections to Azure on the [Connection Types page of the Azure provider](https://airflow.apache.org/docs/apache-airflow-providers-microsoft-azure/stable/connections/index.html).
+- Search for the relevant provider in the [Astronomer Registry](https://registry.astronomer.io/), and click on the `Docs` button to find documentation for the provider. Most commonly used providers will have documentation on each of their associated `Connection types`. For example, you can find information on how to set up different connections to Azure on the [Connection Types page of the Azure provider](https://airflow.apache.org/docs/apache-airflow-providers-microsoft-azure/stable/connections/index.html).
 - Check the documentation of the external tool you are connecting to and see if it offers guidance on how to authenticate.
 - Refer to the source code of the hook that is being used by your operator.
 
-
-
 For example, the `S3Hook`, which is part of the [Amazon provider](https://registry.astronomer.io/providers/amazon), requires a connection of the type `Amazon S3`.
-
 
 ## Define connections in the UI
 
@@ -68,17 +65,13 @@ The fields on the lefthand side may change depending on which 'Connection Type' 
 
 > **Note**: Specific connection types will only be available in the dropdown menu if the relevant provider is installed in your Airflow environment.  
 
-For most connections it is not necessary to specify all fields. The example below shows a connection made to an Amazon S3 bucket using the AWS access key ID as `login` and the AWS secret access key as `password` (See the [AWS documentation](https://docs.aws.amazon.com/powershell/latest/userguide/pstools-appendix-sign-up.html) for how to retrieve your AWS access key ID and AWS secret access key).
+For most connections it is not necessary to specify all fields. The example below shows a connection made to an Amazon S3 bucket. Referencing the [Airflow AWS provider documentation](https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/connections/aws.html) you can learn that the mandatory information needed to create this connection are the AWS access key ID as `login` and the AWS secret access key as `password` (See the [AWS documentation](https://docs.aws.amazon.com/powershell/latest/userguide/pstools-appendix-sign-up.html) for how to retrieve your AWS access key ID and AWS secret access key).
 
 ![Example AWS S3 connection](https://assets2.astronomer.io/main/guides/connections/AWSS3connection.png)
 
 Any required parameters that do not have specific fields in the connection form can be provided to the `Extra` field as a JSON dictionary. For example, you can add the [ARN of a role](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html) to assume when logging into AWS by entering `{"role_arn":"arn:aws:iam::123456789012:role/my_role_name"}` in the `Extra` field. To learn more about additional parameters for a specific connection type, refer to the documentation of the relevant provider package.
 
 In Airflow version 2.2+, you can test some connection types from the Airflow UI with the `Test` button. After running a connection test, a message will appear on the top of the screen either confirming a successful connection or providing an error message.
-
-### Masking sensitive information
-
-Connections often contain sensitive credentials. By default, Airflow will hide the connection password, both in the UI and in the Airflow logs. Values from the connection's `Extra` field will also be hidden if their key contains any of the words listed in the environment variable `AIRFLOW__CORE__SENSITIVE_VAR_CONN_NAMES`, as long as `AIRFLOW__CORE__HIDE_SENSITIVE_VAR_CONN_FIELDS` is set to `True`. You can find more information on masking, including a list of the default values in this environment variable, in the Airflow documentation on [Masking sensitive data](https://airflow.apache.org/docs/apache-airflow/stable/security/secrets/mask-sensitive-values.html).
 
 ## Define connections via environment variables
 
@@ -88,7 +81,7 @@ Connections can also be defined using environment variables. Astro CLI users can
 
 The environment variable used for the connection needs to be in the form of `AIRFLOW_CONN_YOURCONNID` and can be provided either in URI or, starting with Airflow 2.3, in JSON format.
 
-URI (Uniform Resource Identifier) is a format designed to contain all necessary connection information in one string, starting with the connection type, followed by login, password and host. In many cases a specific port, schema, and additional parameters will be added.
+[URI (Uniform Resource Identifier)](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier) is a format designed to contain all necessary connection information in one string, starting with the connection type, followed by login, password and host. In many cases a specific port, schema, and additional parameters will be added.
 
 ```Dockerfile
 
@@ -118,6 +111,10 @@ AIRFLOW_CONN_MYCONNID='{
 ```
 
 Note that connections that are defined using environment variables will not show up in the list of connections in the Airflow UI.
+
+## Masking sensitive information
+
+Connections often contain sensitive credentials. By default, Airflow will hide the connection password, both in the UI and in the Airflow logs. Values from the connection's `Extra` field will also be hidden if their key contains any of the words listed in the environment variable `AIRFLOW__CORE__SENSITIVE_VAR_CONN_NAMES`, as long as `AIRFLOW__CORE__HIDE_SENSITIVE_VAR_CONN_FIELDS` is set to `True`. You can find more information on masking, including a list of the default values in this environment variable, in the Airflow documentation on [Masking sensitive data](https://airflow.apache.org/docs/apache-airflow/stable/security/secrets/mask-sensitive-values.html).
 
 ## Example: Configuring the SnowflakeToSlackOperator
 

--- a/guides/connections.md
+++ b/guides/connections.md
@@ -26,7 +26,7 @@ To get the most out of this guide, you should have knowledge of:
 
 ## Airflow connection basics
 
-A Airflow connection is a set of configurations for sending requests to the API of an external tool. In most cases, a connection requires login credentials or a private key to authenticate Airflow to the external tool.
+An Airflow connection is a set of configurations for sending requests to the API of an external tool. In most cases, a connection requires login credentials or a private key to authenticate Airflow to the external tool.
 
 Airflow connections can be created by using one of the following methods:
 
@@ -39,18 +39,15 @@ Airflow connections can be created by using one of the following methods:
 
 This guide focuses on how to add connections using both the Airflow UI and environment variables. For more in-depth information on configuring connections using the other methods, see the [REST API reference](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html#tag/Connection), [Managing Connections](https://airflow.apache.org/docs/apache-airflow/stable/howto/connection.html) and [Secrets Backend](https://airflow.apache.org/docs/apache-airflow/stable/security/secrets/secrets-backend/index.html) in the Airflow documentation.
 
-Each connection has a unique `conn_id` which can be provided to operators and hooks that require a connection.
+Each connection has a unique `conn_id` which can be provided to operators and [hooks](https://www.astronomer.io/guides/what-is-a-hook/) that require a connection.
 
-Under the hood, Airflow [hooks](https://www.astronomer.io/guides/what-is-a-hook/) use connections to authenticate to external systems in order to send API requests. Most hooks that require connections are part of provider packages.
-
-To standardize connections, Airflow includes many different **connection types** for connecting to specific types of systems. There are general connection types for connecting to large clouds, such as `aws_default` and `gcp_default`, as well as connection types for specific services like `azure_service_bus_default`. 
+To standardize connections, Airflow includes many different **connection types** for connecting to specific types of systems. There are general connection types for connecting to large clouds, such as `aws_default` and `gcp_default`, as well as connection types for specific services like `azure_service_bus_default`.
 
 Each connection type requires different configurations and values based on the service it's connecting to. There are a couple of ways find the information you need to provide for a particular connection type:
 
 - Open the relevant provider's page in the [Astronomer Registry](https://registry.astronomer.io/providers/) and go to the **Docs** tab to access the Apache Airflow documentation for the provider. Most commonly used providers will have documentation on each of their associated connection types. For example, you can find information on how to set up different connections to Azure on the [Azure provider docs](https://registry.astronomer.io/providers/microsoft-azure).
 - Check the documentation of the external tool you are connecting to and see if it offers guidance on how to authenticate.
 - Refer to the source code of the hook that is being used by your operator.
-
 
 ## Define connections in the UI
 
@@ -62,21 +59,21 @@ Airflow doesn't include any configured connections by default. To create a new c
 
 ![Empty Connection](https://assets2.astronomer.io/main/guides/connections/EmptyConnection.png)
 
-As you update the **Connection Type** field, notice how the other available fields change. Each connection type requires different kinds of information. 
+As you update the **Connection Type** field, notice how the other available fields change. Each connection type requires different kinds of information.
 
 > **Note**: Specific connection types will only be available in the dropdown menu if the relevant provider is installed in your Airflow environment.  
 
-You don't have to specify every field on most connections. However, the values marked as required in the Airflow UI can be misleading. For example, the following example is a connection for an Amazon S3 bucket. We need to reference the [Airflow AWS provider documentation](https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/connections/aws.html) to learn that the connection requires the AWS access key ID as `login` and the AWS secret access key as `password`.
+You don't have to specify every field on most connections. However, the values marked as required in the Airflow UI can be misleading. For example to set up a connection to a PostgreSQL database, we need to reference the [PostgreSQL provider documentation](https://airflow.apache.org/docs/apache-airflow-providers-postgres/stable/connections/postgres.html) to learn that the connection requires a `Host`, a user name as `login` and a password in the `password` field.
 
-![Example AWS S3 connection](https://assets2.astronomer.io/main/guides/connections/AWSS3connection.png)
+![Example PostgreSQL connection](https://assets2.astronomer.io/main/guides/connections/PostgreSQLconnection.png)
 
-Any required parameters that do not have specific fields in the connection form can be provided to the **Extra** field as a JSON dictionary. For example, you can add the [ARN of a role](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html) to assume when logging into AWS by specifying `{"role_arn":"arn:aws:iam::123456789012:role/my_role_name"}` in the **Extra** field.
+Any parameters that do not have specific fields in the connection form can be provided to the **Extra** field as a JSON dictionary. For example, you can add the `sslmode` or a client `sslkey` in the **Extra** field of your PostgreSQL connection.
 
 Starting in Airflow 2.2, you can test some connection types from the Airflow UI with the **Test** button. After running a connection test, a message appears on the top of the screen showing either a success confirmation or an error message.
 
 ## Define connections via environment variables
 
-Connections can also be defined using environment variables. If you use the Astro CLI, you use the `.env` file for local development or specify environment variables in your project's Dockerfile.
+Connections can also be defined using environment variables. If you use the Astro CLI, you can use the `.env` file for local development or specify environment variables in your project's Dockerfile.
 
 > **Note**: If you are synchronizing your project to a remote repository, don't save sensitive information in your Dockerfile. In this case, using either a secrets backend, Airflow connections defined in the UI, or `.env` locally are preferred so as to not expose secrets in plain text.
 
@@ -116,13 +113,13 @@ Note that connections that are defined using environment variables do not appear
 
 ## Masking sensitive information
 
-Connections often contain sensitive credentials. By default, Airflow hides the `password` field, both in the UI and in the Airflow logs. If `AIRFLOW__CORE__HIDE_SENSITIVE_VAR_CONN_FIELDS` is set to `True`, values from the connection's `Extra` field are also hidden if their keys contain any of the words listed in  `AIRFLOW__CORE__SENSITIVE_VAR_CONN_NAMES`. You can find more information on masking, including a list of the default values in this environment variable, in the Airflow documentation on [Masking sensitive data](https://airflow.apache.org/docs/apache-airflow/stable/security/secrets/mask-sensitive-values.html).
+Connections often contain sensitive credentials. By default, Airflow hides the `password` field, both in the UI and in the Airflow logs. If `AIRFLOW__CORE__HIDE_SENSITIVE_VAR_CONN_FIELDS` is set to `True`, values from the connection's `Extra` field are also hidden if their keys contain any of the words listed in `AIRFLOW__CORE__SENSITIVE_VAR_CONN_NAMES`. You can find more information on masking, including a list of the default values in this environment variable, in the Airflow documentation on [Masking sensitive data](https://airflow.apache.org/docs/apache-airflow/stable/security/secrets/mask-sensitive-values.html).
 
 ## Example: Configuring the SnowflakeToSlackOperator
 
 In this example, we configure the `SnowflakeToSlackOperator`, which requires connections to Snowflake and Slack. We define the connections using the Airflow UI.
 
-Before starting Airflow, we need to install both the [Snowflake](https://registry.astronomer.io/providers/snowflake) and the [Slack provider](https://registry.astronomer.io/providers/slack). If you use the Astro CLI, you can can add install the packages by adding the following lines to your Astro project's `requirements.txt` file:
+Before starting Airflow, we need to install both the [Snowflake](https://registry.astronomer.io/providers/snowflake) and the [Slack provider](https://registry.astronomer.io/providers/slack). If you use the Astro CLI, you can install the packages by adding the following lines to your Astro project's `requirements.txt` file:
 
 ```text
 apache-airflow-providers-snowflake
@@ -149,7 +146,7 @@ To connect to Slack from Airflow, you only have to provide a few parameters:
 
 - Connection Id: `slack_conn` (or another string that has not been used for a different connection already)
 - Connection Type: `Slack Webhook`
-- Host: `https://hooks.slack.com.services`, or the the first part of your Webhook URL
+- Host: `https://hooks.slack.com.services`, which is the first part of your Webhook URL
 - Password: The second part of your Webhook URL in the format `T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX`
 
 Test the connection by clicking on the `Test` button.

--- a/guides/connections.md
+++ b/guides/connections.md
@@ -24,34 +24,39 @@ To get the most out of this guide, you should have knowledge of:
 - Airflow operators. See [Operators 101](https://www.astronomer.io/guides/what-is-an-operator).
 - Airflow hooks. See [Hooks 101](https://www.astronomer.io/guides/what-is-a-hook/).
 
-## Airflow connection essentials
+## Airflow connection basics
 
-A connection in Airflow is a set of configurations containing the information necessary to send requests to the API of an external tool. The information a connection needs to contain will vary based on which tool you are connecting to. In most cases a connection necessitates login credentials or a private key in order to authenticate Airflow to the external tool.
+A connection in Airflow is a set of configurations containing the information necessary to send requests to the API of an external tool. The information contained in a connection will vary based on the requirements of the external tool. In most cases, a connection will require login credentials or a private key in order to authenticate Airflow to the external tool.
 
-Airflow connections can be defined in multiple ways, using:
+Airflow connections can be created by using one of the following methods:
 
-- **The Airflow UI**: The most straightforward way to add connections directly from the UI.
-- **Environment variables**: Add connections that are completely hidden from the UI.
-- **The [Airflow REST API](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html#tag/Connection)**: Add a connection using an API call.
-- **A secrets backend**: Integrate Airflow with a secrets backend solution that can store credentials and sensitive values to be used by Airflow.
-- The `airflow.cfg` file: Add connections by modifying a configuration file.
-- The Airflow CLI: Add connections by running a CLI command.
+- The Airflow UI
+- Environment variables
+- The [Airflow REST API](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html#tag/Connection)
+- A secrets backend (a system for managing secrets external to Airflow)
+- The `airflow.cfg` file
+- The Airflow CLI
 
-In this guide we will cover adding connections using the Airflow UI and environment variables. For more in-depth information on configuring connections in other ways see the REST API documentation, as well as ['Managing Connections'](https://airflow.apache.org/docs/apache-airflow/stable/howto/connection.html) and ['Secrets Backend'](https://airflow.apache.org/docs/apache-airflow/stable/security/secrets/secrets-backend/index.html) in the Airflow documentation.
-
-To discover which information to provide to which field you can search for the relevant provider in the [Astronomer Registry](https://registry.astronomer.io/) and click on the `Docs` button to find documentation on a specific provider. Most common providers will have documentation on each of their associated `Connection types`. For example, you can find information on how to set up different connections to Azure on the [Connection Types page of the Azure provider](https://airflow.apache.org/docs/apache-airflow-providers-microsoft-azure/stable/connections/index.html).
-
-> **Note**: If you cannot find the relevant information in the Apache Airflow documentation on the external tool you are trying to connect to, see if the documentation of the external tool offers guidance on how to authenticate to it or refer to the source code of the hook that is being used by your operator.
-
-Under the hood, Airflow [hooks](https://www.astronomer.io/guides/what-is-a-hook/) use connections to authenticate to external systems in order to send API requests. Most hooks that require connections are part of provider packages.
-
-For example, the `S3Hook`, which is part of the [Amazon provider](https://registry.astronomer.io/providers/amazon), requires a connection of the type `Amazon S3`.
+In this guide we will show how to add connections using the Airflow UI and environment variables methods. For more in-depth information on configuring connections using the other methods, see the REST API documentation, as well as ['Managing Connections'](https://airflow.apache.org/docs/apache-airflow/stable/howto/connection.html) and ['Secrets Backend'](https://airflow.apache.org/docs/apache-airflow/stable/security/secrets/secrets-backend/index.html) in the Airflow documentation.
 
 Each connection is associated with a unique `conn_id`, which can be provided to operators and hooks requiring a connection.
 
+Under the hood, Airflow [hooks](https://www.astronomer.io/guides/what-is-a-hook/) use connections to authenticate to external systems in order to send API requests. Most hooks that require connections are part of provider packages.
+
+There are a couple of ways you can find what information needs to be provided for a particular connection type:
+
+- Search for the relevant provider in the [Astronomer Registry](https://registry.astronomer.io/), and click on the `Docs` button to find documentation for provider. Most commonly used providers will have documentation on each of their associated `Connection types`. For example, you can find information on how to set up different connections to Azure on the [Connection Types page of the Azure provider](https://airflow.apache.org/docs/apache-airflow-providers-microsoft-azure/stable/connections/index.html).
+- Check the documentation of the external tool you are connecting to and see if it offers guidance on how to authenticate.
+- Refer to the source code of the hook that is being used by your operator.
+
+
+
+For example, the `S3Hook`, which is part of the [Amazon provider](https://registry.astronomer.io/providers/amazon), requires a connection of the type `Amazon S3`.
+
+
 ## Define connections in the UI
 
-The most common way of defining a connection is using the Airflow UI. Click on the **Admin** in the navigation bar and select **Connections**.
+The most common way of defining a connection is using the Airflow UI. Click on the **Admin** tab in the navigation bar and select **Connections**.
 
 ![Connections seen from the DAG view](https://assets2.astronomer.io/main/guides/connections/DAGview_connections.png)
 
@@ -63,27 +68,27 @@ The fields on the lefthand side may change depending on which 'Connection Type' 
 
 > **Note**: Specific connection types will only be available in the dropdown menu if the relevant provider is installed in your Airflow environment.  
 
-For most connections it is not necessary to specify all fields. The example below shows a connection made to an Amazon S3 bucket using the AWS access key ID as `login` and the AWS secret access key as `password` ([See AWS documentation for how to retrieve your AWS access key ID and AWS secret access key](https://docs.aws.amazon.com/powershell/latest/userguide/pstools-appendix-sign-up.html)).
+For most connections it is not necessary to specify all fields. The example below shows a connection made to an Amazon S3 bucket using the AWS access key ID as `login` and the AWS secret access key as `password` (See the [AWS documentation](https://docs.aws.amazon.com/powershell/latest/userguide/pstools-appendix-sign-up.html) for how to retrieve your AWS access key ID and AWS secret access key).
 
 ![Example AWS S3 connection](https://assets2.astronomer.io/main/guides/connections/AWSS3connection.png)
 
-It is possible to pass additional configuration parameters to a connection by providing them to the `Extra` field as a JSON. For example it would be possible to add the [ARN of a role](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html) to assume when logging into AWS by entering `{"role_arn":"arn:aws:iam::123456789012:role/my_role_name"}` in the `Extra` field. To learn about additional parameters for a specific connection type please refer to the documentation of the relevant provider package.
+Any required parameters that do not have specific fields in the connection form can be provided to the `Extra` field as a JSON dictionary. For example, you can add the [ARN of a role](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html) to assume when logging into AWS by entering `{"role_arn":"arn:aws:iam::123456789012:role/my_role_name"}` in the `Extra` field. To learn more about additional parameters for a specific connection type, refer to the documentation of the relevant provider package.
 
-In Airflow version 2.2+ some connection types offer the possibility to test the connection from the Airflow UI. A message either confirming a successful connection or providing an error message will appear on top of the screen after running a connection test.
+In Airflow version 2.2+, you can test some connection types from the Airflow UI with the `Test` button. After running a connection test, a message will appear on the top of the screen either confirming a successful connection or providing an error message.
 
 ### Masking sensitive information
 
-Connections often contain sensitive credentials. By default Airflow will hide the connection password, both in the UI and in the Airflow logs. Values from the Connection's `Extra` field will also be hidden if their key contains any of the words listed in the environment variable `AIRFLOW__CORE__SENSITIVE_VAR_CONN_NAMES`, as long as `AIRFLOW__CORE__HIDE_SENSITIVE_VAR_CONN_FIELDS` is set to `True`. You can find more information on masking including a list of the default values of this environment variable in the Airflow documentation on [Masking sensitive data](https://airflow.apache.org/docs/apache-airflow/stable/security/secrets/mask-sensitive-values.html).
+Connections often contain sensitive credentials. By default, Airflow will hide the connection password, both in the UI and in the Airflow logs. Values from the connection's `Extra` field will also be hidden if their key contains any of the words listed in the environment variable `AIRFLOW__CORE__SENSITIVE_VAR_CONN_NAMES`, as long as `AIRFLOW__CORE__HIDE_SENSITIVE_VAR_CONN_FIELDS` is set to `True`. You can find more information on masking, including a list of the default values in this environment variable, in the Airflow documentation on [Masking sensitive data](https://airflow.apache.org/docs/apache-airflow/stable/security/secrets/mask-sensitive-values.html).
 
 ## Define connections via environment variables
 
 Connections can also be defined using environment variables. Astro CLI users can use the `.env` file for local development, or specify environment variables in the Dockerfile.
 
-> **Note**: If you are synchronizing your project using a public remote repository, make sure not to save sensitive information in the Dockerfile. In this case using either a secrets backend, Airflow connections defined in the UI or `.env` locally is preferred as to not expose secrets in plain text.
+> **Note**: If you are synchronizing your project to a remote repository, don't save sensitive information in your Dockerfile. In this case, using either a secrets backend, Airflow connections defined in the UI, or `.env` locally are preferred so as to not expose secrets in plain text.
 
 The environment variable used for the connection needs to be in the form of `AIRFLOW_CONN_YOURCONNID` and can be provided either in URI or, starting with Airflow 2.3, in JSON format.
 
-URI (Uniform Resource Identifier) is a format designed to contain all necessary connection information in one string, starting with the connection type followed by login, password and host. In many cases a specific port and schema, as well as additional parameters will be added.
+URI (Uniform Resource Identifier) is a format designed to contain all necessary connection information in one string, starting with the connection type, followed by login, password and host. In many cases a specific port, schema, and additional parameters will be added.
 
 ```Dockerfile
 
@@ -95,7 +100,7 @@ ENV AIRFLOW_CONN_snowflake_conn='snowflake://LOGIN:PASSWORD@/?account=xy12345&re
 
 ```
 
-In Airflow 2.3+, connections can alternatively be provided as a JSON (in this example defined from `.env`).
+In Airflow 2.3+, connections can alternatively be provided as a JSON dictionary (in this example defined in `.env`).
 
 ```text
 AIRFLOW_CONN_MYCONNID='{
@@ -112,11 +117,11 @@ AIRFLOW_CONN_MYCONNID='{
 }'
 ```
 
-Note that connections that are defined using environment variables will not show up in the list of connections in the Airflow UI and which parameters to specify can very for different connection types.
+Note that connections that are defined using environment variables will not show up in the list of connections in the Airflow UI.
 
 ## Example: Configuring the SnowflakeToSlackOperator
 
-In this example, we will configure the `SnowflakeToSlackOperator`, which requires connections to Snowflake and Slack. We will define the connections using the Airflow UI.
+In this example, we configure the `SnowflakeToSlackOperator`, which requires connections to Snowflake and Slack. We define the connections using the Airflow UI.
 
 Before starting Airflow, we need to install both the [Snowflake](https://registry.astronomer.io/providers/snowflake) and the [Slack provider](https://registry.astronomer.io/providers/slack). Astro CLI users can add them to `requirements.txt`:
 
@@ -125,7 +130,7 @@ apache-airflow-providers-snowflake
 apache-airflow-providers-slack
 ```
 
-In the Airflow UI, we can navigate to the list of connections and add a connection of the 'Connection Type' `Snowflake`. The following parameters are required:
+In the Airflow UI, we navigate to the list of connections and add a connection of the 'Connection Type' `Snowflake`. The following parameters are required:
 
 - Connection Id: `snowflake_conn` (or another string that has not been used for a different connection already)
 - Connection Type: `Snowflake`
@@ -150,7 +155,7 @@ To connect to Slack from Airflow, you only have to provide a few parameters:
 
 Test the connection by clicking on the `Test` button.
 
-The last step is writing the DAG using the `SnowflakeToSlackOperator` to run a SQL query on a Snowflake table and post the result as a message to a Slack channel. The `SnowflakeToSlackOperator` needs both, the connection id pointing towards the snowflake connection `snowflake_conn_id` and the connection id for the Slack connection `slack_conn_id`.
+The last step is writing the DAG using the `SnowflakeToSlackOperator` to run a SQL query on a Snowflake table and post the result as a message to a Slack channel. The `SnowflakeToSlackOperator` requires both the connection id for the Snowflake connection (`snowflake_conn_id`) and the connection id for the Slack connection (`slack_conn_id`).
 
 ```Python
 from airflow import DAG

--- a/guides/connections.md
+++ b/guides/connections.md
@@ -73,7 +73,7 @@ In Airflow version 2.2+ some connection types offer the possibility to test the 
 
 ### Masking sensitive information
 
-Connections often contain sensitive credentials. By default Airflow will hide the connection password, both in the UI and in the Airflow logs. Values from the Connection's `Extra` field will also be hidden if their key contains any of the words listed in the environment variable `AIRFLOW__CORE__SENSITIVE_VAR_CONN_NAMES`, as long as `AIRLFOW__CORE__HIDE_SENSITIVE_VAR_CONN_FIELDS` is set to `True`. You can find more information on masking including a list of the default values of this environment variable in the Airflow documentation on [Masking sensitive data](https://airflow.apache.org/docs/apache-airflow/stable/security/secrets/mask-sensitive-values.html).
+Connections often contain sensitive credentials. By default Airflow will hide the connection password, both in the UI and in the Airflow logs. Values from the Connection's `Extra` field will also be hidden if their key contains any of the words listed in the environment variable `AIRFLOW__CORE__SENSITIVE_VAR_CONN_NAMES`, as long as `AIRFLOW__CORE__HIDE_SENSITIVE_VAR_CONN_FIELDS` is set to `True`. You can find more information on masking including a list of the default values of this environment variable in the Airflow documentation on [Masking sensitive data](https://airflow.apache.org/docs/apache-airflow/stable/security/secrets/mask-sensitive-values.html).
 
 ## Define connections via environment variables
 

--- a/guides/connections.md
+++ b/guides/connections.md
@@ -31,14 +31,14 @@ A connection in Airflow is a set of configurations containing the information ne
 
 Airflow connections can be defined in multiple ways, using:
 
-- The Airflow UI
-- Environment variables
-- The [Airflow REST API](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html#tag/Connection)
-- A secrets backend
-- The `airflow.cfg` file
-- The Airflow CLI
+- **The Airflow UI**: The most straightforward way to add connections directly from the UI.
+- **Environment variables**: Add connections that are completely hidden from the UI.
+- **The [Airflow REST API](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html#tag/Connection)**: Add a connection using an API call.
+- **A secrets backend**: Integrate Airflow with a secrets backend solution that can store credentials and sensitive values to be used by Airflow.
+- The `airflow.cfg` file: Add connections by modifying a configuration file.
+- The Airflow CLI: Add connections by running a CLI command.
 
-In this guide we will cover adding connections using the Airflow UI and environment variables. For more in-depth information on configuring connections in other ways see ['Managing Connections'](https://airflow.apache.org/docs/apache-airflow/stable/howto/connection.html) and ['Secrets Backend'](https://airflow.apache.org/docs/apache-airflow/stable/security/secrets/secrets-backend/index.html) in the Airflow documentation.
+In this guide we will cover adding connections using the Airflow UI and environment variables. For more in-depth information on configuring connections in other ways see the REST API documentation, as well as ['Managing Connections'](https://airflow.apache.org/docs/apache-airflow/stable/howto/connection.html) and ['Secrets Backend'](https://airflow.apache.org/docs/apache-airflow/stable/security/secrets/secrets-backend/index.html) in the Airflow documentation.
 
 To discover which information to provide to which field you can search for the relevant provider in the [Astronomer Registry](https://registry.astronomer.io/) and click on the `Docs` button to find documentation on a specific provider. Most common providers will have documentation on each of their associated `Connection types`. For example, you can find information on how to set up different connections to Azure on the [Connection Types page of the Azure provider](https://airflow.apache.org/docs/apache-airflow-providers-microsoft-azure/stable/connections/index.html).
 


### PR DESCRIPTION
Added a few new chapters:
- Airflow connection essentials: Was on the fence on whether this section is needed but it also felt like too much information for the intro paragraph. I'm linking out to the Hooks guide here for more advanced users, but am open to deleting that part if we don't want to go into depth
- Define connections in the UI: This now has only one example (Amazon S3) I deleted the other example connection configurations.
- Define connections via environment variables: This is a short overview highlighting the JSON format that was added in 2.3.0. Linking out to Airflow docs for in depth explanations, including custom connections.
- Example: Configuring the SnowflakeToSlackOperator: I was thinking a transfer operator is perfect to show different connections. 

I modified the existing chapter on programmatic access to connections to explain access to the session first in a small example in a full DAG and then explain the provided function for looping over information from a secrets manager in more depth. 🙂 